### PR TITLE
Use manifest.mf from maven's $(project.basedir) instead of the 1st <packaging:module> in tibco.xml

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARPackagerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARPackagerMojo.java
@@ -151,13 +151,15 @@ public class BWEARPackagerMojo extends AbstractMojo {
     private void addModules() throws Exception {
     	try {
         	getLog().debug("Adding Modules to the Application EAR");
-        	// The first artifact is an Application Module
-        	boolean isAppModuleArtifact = true;
+        	
+        	// Use manifest of project.basedir
+        	this.version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
+        	
         	BWModulesParser parser = new BWModulesParser(session, project);
         	String bwEdition = manifest.getMainAttributes().getValue(Constants.TIBCO_BW_EDITION);
         	parser.bwEdition = bwEdition;
+        	
         	List<Artifact> artifacts = parser.getModulesSet();
-
             for(Artifact artifact : artifacts) {
                 //Find the Module JAR file
                 File moduleJar = artifact.getFile();
@@ -169,10 +171,6 @@ public class BWEARPackagerMojo extends AbstractMojo {
 
                 //Save the module version in the Version Map.
                 moduleVersionMap.put(artifact.getArtifactId(), version);
-                if(isAppModuleArtifact) {
-                	this.version = version;
-                	isAppModuleArtifact = false;
-                }
             }
     	} catch(Exception e) {
     		getLog().error("Failed to add modules to the Application");


### PR DESCRIPTION
When using pom.xml with multiple source code modules, the generated ear file does not always have the right version in the manifest. (It currently use the version of the 1st <packaging:module> of the tibco.xml)

Ex:
pom.xml defines 2 modules: 
 app.bwsm - v1.1.0
 app.bwapp - v1.0.0

We expected the manifest of app.bwapp to be v1.0.0 but it was v1.1.0 because of the order define in TIBCO.xml

This patch uses manifest.mf that is currently in project.basedir 

