### PR TITLE
Add MojoExecutionException in case the deploy is not successful

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
@@ -171,7 +171,7 @@ public class BWEARInstallerMojo extends AbstractMojo {
     		deployer.addAndDeployApplication(domain, appSpace, applicationName, earName, files[0].getAbsolutePath(), redeploy, profile, backup, backupLocation);
     		deployer.close();
     	} catch(Exception e) {
-    		getLog().error(e);
+		throw new MojoExecutionException("Failed to install BW EAR application -> ", e);
     	}
     }
 


### PR DESCRIPTION
When the application fails to deploy or start successfully, some tibco error might be returned, but the maven command returns "build / deployed successfully" 
In a CI / CD environment, this cause problem because all those anomalies are not reported...