### PR TITLE
Fix for https://github.com/TIBCOSoftware/bw6-plugin-maven/issues/79

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
@@ -2,6 +2,7 @@ package com.tibco.bw.maven.plugin.module;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -124,13 +125,17 @@ public class BWModulePackageMojo extends AbstractMojo {
             // Code for BWCE
             String bwEdition = manifest.getMainAttributes().getValue(Constants.TIBCO_BW_EDITION);
             if(bwEdition != null && bwEdition.equals(Constants.BWCF)) {
-            	List<MavenProject> projs = session.getAllProjects();
-            	for(int i = 0; i < projs.size(); i++) {
-            		MavenProject proj = projs.get(i);
-            		if(proj.getArtifactId().equals(project.getArtifactId())) {
-        				session.getAllProjects().set(i, project);
-        			}
-            	}
+            	List<MavenProject> amendedProjects = new ArrayList<>();
+            	for(MavenProject proj: session.getAllProjects())
+				{
+					if(proj.getArtifactId().equals(project.getArtifactId())) {
+						amendedProjects.add(project);
+					}
+					else {
+						amendedProjects.add(proj);
+					}
+				}
+            	session.setAllProjects(amendedProjects);
             }
             getLog().info("BW Module Packager Mojo finished execution.");
     	} catch (IOException e) {


### PR DESCRIPTION
Maven 3.5 returns an immutable List for MavenSession.getAllProjects().

The plugin was trying to mutate the list when building BWCE projects, making the build fail with a java.lang.UnsupportedOperationException.

Modified the code so that it builds up a new List of sessions when building BWCE projects and calls MavenSession.setAllProjects(modifiedList) in order to update the session list for the MavenSession.

