### PR TITLE
Enabling external SM to be used as dependencies in BW6

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
@@ -42,6 +42,7 @@ import com.tibco.bw.maven.plugin.build.BuildPropertiesParser;
 import com.tibco.bw.maven.plugin.osgi.helpers.ManifestParser;
 import com.tibco.bw.maven.plugin.osgi.helpers.ManifestWriter;
 import com.tibco.bw.maven.plugin.osgi.helpers.VersionParser;
+import com.tibco.bw.maven.plugin.utils.BWProjectUtils;
 import com.tibco.bw.maven.plugin.utils.Constants;
 
 @Mojo(name = "bwmodule", defaultPhase = LifecyclePhase.PACKAGE)
@@ -258,6 +259,17 @@ public class BWModulePackageMojo extends AbstractMojo {
         if(includes.contains("target/")) {
         	includes.remove("target/");
         }
+        
+        if(isSharedModule()){
+        	//Ensure .project and .config are added
+        	if(!includes.contains(".config")){
+        		includes.add(".config");
+        	}
+        	if(!includes.contains(".project")){
+        		includes.add(".project");
+        	}
+        }
+        
         if (includes.isEmpty()) {
             fileSet.setIncludes(new String[] { "" });
         } else {
@@ -271,6 +283,11 @@ public class BWModulePackageMojo extends AbstractMojo {
         fileSet.setExcludes(allExcludes.toArray(new String[allExcludes.size()]));
         return fileSet;
     }
+    
+    protected boolean isSharedModule(){
+    	return manifest.getMainAttributes().getValue(Constants.TIBCO_SHARED_MODULE) == null ? false : true;
+    }
+    
 
     private void updateManifestVersion() {
     	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/BWModulesParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/BWModulesParser.java
@@ -39,6 +39,19 @@ public class BWModulesParser {
 		}
 		return list;
 	}
+	
+	public List<MavenProject> getModulesProjectSet(){
+		List<MavenProject> list = new ArrayList<MavenProject>();
+		List<String> modules = getModulesFromTibcoXML();
+		for(String module : modules) {
+			MavenProject project = getProjectForModule(module);
+			if(project != null) {
+				list.add(project);	
+			}
+		}
+		
+		return list;
+	}
 
 	private List<String> getModulesFromTibcoXML() {
 		List<String> modules = new ArrayList<String>();
@@ -79,6 +92,22 @@ public class BWModulesParser {
 			if(project.getArtifactId().equals(module)) {
 				Artifact artifact = project.getArtifact();
 				return artifact;
+			}
+		}
+		return null;
+	}
+	
+	private MavenProject getProjectForModule(String module){
+		List<MavenProject> projects = new ArrayList<MavenProject>();
+		if(bwEdition != null && bwEdition.equals(Constants.BWCF)) {
+			projects = session.getAllProjects();
+		} else {
+			projects = session.getProjects();
+		}
+
+		for(MavenProject project : projects) {
+			if(project.getArtifactId().equals(module)) {
+				return project;
 			}
 		}
 		return null;

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/Constants.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/Constants.java
@@ -13,4 +13,5 @@ public interface Constants {
 	public static final String TECHNOLOGY_VERSION = "technologyVersion";
 	public static final String BASIC_AUTH = "BASIC";
 	public static final String DIGEST_AUTH = "DIGEST";
+	public static final String TIBCO_SHARED_MODULE = "TIBCO-BW-SharedModule";
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/.classpath
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.4.jar"/>

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/META-INF/MANIFEST.MF
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.ui,
  com.tibco.zion.project;bundle-version="[1.3.0,2.0.0)",
  com.tibco.bw.design;bundle-version="[6.3.0,7.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.7.0,2.0.0)",
- org.eclipse.core.expressions;bundle-version="[3.4.600,4.0.0)"
+ org.eclipse.core.expressions;bundle-version="[3.4.600,4.0.0)",
+ org.eclipse.core.filesystem;bundle-version="1.4.100"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/commons-io-2.4.jar,

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/META-INF/MANIFEST.MF
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/META-INF/MANIFEST.MF
@@ -15,7 +15,10 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.m2e.core.ui;bundle-version="[1.3.1,2.0.0)",
  com.tibco.bw.core.design.debug.ui;bundle-version="[6.2.200,7.0.0)",
  com.tibco.bw.tpcl.org.cloudfoundry.client;bundle-version="[1.1.2,2.0.0)",
- com.tibco.zion.project;bundle-version="[1.3.0,2.0.0)"
+ com.tibco.zion.project;bundle-version="[1.3.0,2.0.0)",
+ com.tibco.bw.design;bundle-version="[6.3.0,7.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.7.0,2.0.0)",
+ org.eclipse.core.expressions;bundle-version="[3.4.600,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/commons-io-2.4.jar,

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/META-INF/MANIFEST.MF
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.ui,
  com.tibco.bw.design;bundle-version="[6.3.0,7.0.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.7.0,2.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.600,4.0.0)",
- org.eclipse.core.filesystem;bundle-version="1.4.100"
+ org.eclipse.core.filesystem;bundle-version="[1.4.100,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/commons-io-2.4.jar,

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/plugin.xml
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/plugin.xml
@@ -14,5 +14,57 @@
           class="com.tibco.bw.studio.maven.extension.MavenDebugLauncher">
     </Name>
  </extension>
+ <extension point="org.eclipse.ui.commands">
+ 	<command
+        defaultHandler="com.tibco.bw.studio.maven.action.SharedModulePOMActionHandler"
+        description="Generate POM for Shared Module"
+        id="com.tibco.bw.studio.maven.commands.generateSharedModulePom"
+        name="Generate POM for Shared Module">
+	</command>
+ </extension>
+ <extension
+       point="org.eclipse.ui.menus">
+        <menuContribution
+              allPopups="false"
+              locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu?after=com.tibco.bw.binding.rest.design.project.atmos.pushToCloudMenu">
+         <command
+               commandId="com.tibco.bw.studio.maven.commands.generateSharedModulePom"
+               id="com.tibco.bw.studio.maven.menu.generateSMPom"
+               label="Generate POM for Shared Module"
+               style="push">   
+               <visibleWhen
+                  checkEnabled="false">
+               <iterate
+                     ifEmpty="false">
+                  <or>
+                     <test
+                           forcePluginActivation="true"
+                           property="com.tibco.bw.studio.maven.sharedModuleProjectTester">
+                     </test>
+                  </or>
+               </iterate>
+            </visibleWhen>          
+         </command>
+         
+         </menuContribution>
+ </extension>
+ <extension
+         point="org.eclipse.core.expressions.propertyTesters">
+      <propertyTester
+            class="com.tibco.bw.studio.maven.tester.SharedModuleProjectTester"
+            id="com.tibco.bw.studio.maven.sharedModuleProjectTester"
+            namespace="com.tibco.bw.studio.maven"
+            properties="sharedModuleProjectTester"
+            type="java.lang.Object">
+      </propertyTester>
+ </extension>
+ <extension
+       point="com.tibco.bw.design.BWBuilder">
+    <builder
+          configClass="com.tibco.bw.studio.maven.validation.MavenDependenciesBuilder"
+          id="bw6.studio.maven.plugin.mavenDependenciesBuilder"
+          name="MavenDependencyBuilder">
+    </builder>
+ </extension>
 
 </plugin>

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/action/SharedModulePOMActionHandler.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/action/SharedModulePOMActionHandler.java
@@ -1,0 +1,112 @@
+package com.tibco.bw.studio.maven.action;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.internal.events.BuildCommand;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.window.Window;
+
+import com.tibco.bw.studio.maven.helpers.ProjectHelper;
+import com.tibco.bw.studio.maven.modules.BWProjectBuilder;
+import com.tibco.bw.studio.maven.modules.model.BWModule;
+import com.tibco.bw.studio.maven.modules.model.BWProject;
+import com.tibco.bw.studio.maven.plugin.Activator;
+import com.tibco.bw.studio.maven.wizard.MavenWizard;
+import com.tibco.bw.studio.maven.wizard.MavenWizardDialog;
+
+public class SharedModulePOMActionHandler extends AbstractHandler{
+	private IProject selectedProject;
+	private BWProject project;
+	
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		try{
+			selectedProject = ProjectHelper.getCurrentSelectedProject();
+			BWProjectBuilder builder = new BWProjectBuilder();
+			project = builder.buildSMProject(selectedProject);
+			MavenWizard wizard = new MavenWizard(project);
+			MavenWizardDialog dialog = new MavenWizardDialog(ProjectHelper.getActiveShell(), wizard);
+			if(dialog.open() == Window.OK){
+				project = wizard.getProject();
+				generatePOMs();
+				addMavenNature();
+				refreshProjects();
+
+			}else{
+				return null;
+			}
+		} catch(Exception e) {
+			 Activator.logException("Failed to generate the POM file ", IStatus.ERROR, e);		
+		}
+		
+		return null;
+	}
+	
+	private void generatePOMs() {
+		for(BWModule module : project.getModules()) {
+			try	{
+				module.getPOMBuilder().build(project, module);	
+			} catch(Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	private void addMavenNature() {
+		for(BWModule module : project.getModules()) {
+			if(module != null){
+				addMavenNature(module.getProject());
+			}
+		}
+	}
+	
+	private void addMavenNature(IProject project) {
+		try {
+			IProjectDescription desc = project.getDescription();
+
+			String[] prevNatures = desc.getNatureIds();
+			String[] newNatures = new String[prevNatures.length + 1];
+
+			System.arraycopy(prevNatures, 0, newNatures, 0, prevNatures.length);
+
+			newNatures[prevNatures.length] = "org.eclipse.m2e.core.maven2Nature";
+			desc.setNatureIds(newNatures);
+
+			project.setDescription(desc, new NullProgressMonitor());
+
+			ICommand[] commands = desc.getBuildSpec();
+			List<ICommand> commandList = Arrays.asList(commands);
+			ICommand build = new BuildCommand();
+			build.setBuilderName("org.eclipse.m2e.core.maven2Builder");
+			List<ICommand> modList = new ArrayList<>(commandList);
+			modList.add(build);
+			desc.setBuildSpec(modList.toArray(new ICommand[]{}));
+		} catch(Exception e) {
+			 Activator.logException("Failed to add Maven nature to the Project : " + project.getName(), IStatus.ERROR, e);		
+		}
+	}
+
+	/**
+	 * Refresh each of the selected Project. This is required as Maven nature is added to the Project.
+	 * Hence the Projects needs to be refreshed.
+	 * @throws Exception
+	 */
+	private void refreshProjects() throws Exception {
+		for(BWModule module : project.getModules()) {
+			if(module.getProject() != null) {
+				module.getProject().refreshLocal(IResource.DEPTH_INFINITE, null); 
+			}
+		}
+		
+	}
+}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/ModuleHelper.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/ModuleHelper.java
@@ -62,4 +62,14 @@ public class ModuleHelper
 		
 		return null;
 	}
+	
+	public static BWModule getSharedModule(List<BWModule>modules){
+		for(BWModule module : modules){
+			if(module.getType() == BWModuleType.SharedModule){
+				return module;
+			}
+		}
+		
+		return null;
+	}
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/POMHelper.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/POMHelper.java
@@ -2,10 +2,13 @@ package com.tibco.bw.studio.maven.helpers;
 
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 public class POMHelper
 {
@@ -31,6 +34,17 @@ public class POMHelper
 		
 		return model;
 	}
-
 	
+	public static  Model readModelFromPOM( InputStream inputStream){
+		Model model = null;
+		if(inputStream != null){
+			MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
+		    try {
+				model = xpp3Reader.read(inputStream);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+	    }
+	return model;
+	}
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/ProjectHelper.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/ProjectHelper.java
@@ -1,9 +1,16 @@
 package com.tibco.bw.studio.maven.helpers;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.ISelectionService;
+import org.eclipse.ui.PlatformUI;
 
 public class ProjectHelper 
 {
@@ -29,6 +36,29 @@ public class ProjectHelper
 		return project;
 	}
 	
+	/**
+	 * Returns the selected Project. The Project will be always of type Application project.
+	 * 
+	 * @return the Selected Project.
+	 */
+	public static IProject getCurrentSelectedProject() {
+		//Standard code. Taken from Eclipse help.
+		IProject project = null;
+		ISelectionService selectionService = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getSelectionService();
+		ISelection selection = selectionService.getSelection();
+	    if(selection instanceof IStructuredSelection) {
+	        Object element = ((IStructuredSelection)selection).getFirstElement();
+	        if (element instanceof IResource) {
+	            project= ((IResource)element).getProject();
+	        }
+	    }
+	    return project;
+	}
 	
+	public static Shell getActiveShell(){
+		Display display = Display.getDefault();
+		Shell result = display.getActiveShell();
+		return result;
+	}
 
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWProject.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWProject.java
@@ -7,13 +7,22 @@ import java.util.Map;
 
 public class BWProject 
 {
-
+	
 	private BWParent parent;
 
 	private List<BWModule> modules;
 	
 	private Map<String, List<String>> dependencies = new HashMap<String, List<String>>();
 
+	private BWProjectType type;
+	
+	public BWProject() {
+		this.type = BWProjectType.Application;
+	}
+	
+	public BWProject(BWProjectType type){
+		this.type = type;
+	}
 	
 	public List<BWModule> getModules() 
 	{
@@ -50,6 +59,8 @@ public class BWProject
 		this.parent = parent;
 	}
 
-
-	
+	public BWProjectType getType(){
+		return this.type;
+	}
 }
+

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWProjectType.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWProjectType.java
@@ -1,0 +1,6 @@
+package com.tibco.bw.studio.maven.modules.model;
+
+public enum BWProjectType {
+	Application, 
+	SharedModule
+}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
@@ -17,7 +17,7 @@ import com.tibco.bw.studio.maven.modules.model.BWProject;
 import com.tibco.zion.project.core.ContainerPreferenceProject;
 
 public class ModulePOMBuilder extends AbstractPOMBuilder implements IPOMBuilder {
-	private String bwEdition;
+	protected String bwEdition;
 
 	@Override
 	public void build(BWProject project, BWModule module) throws Exception {

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/SharedModulePOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/SharedModulePOMBuilder.java
@@ -1,5 +1,45 @@
 package com.tibco.bw.studio.maven.pom.builders;
 
+import com.tibco.bw.studio.maven.modules.model.BWAppModule;
+import com.tibco.bw.studio.maven.modules.model.BWModule;
+import com.tibco.bw.studio.maven.modules.model.BWPluginModule;
+import com.tibco.bw.studio.maven.modules.model.BWProject;
+import com.tibco.bw.studio.maven.modules.model.BWProjectType;
+
 public class SharedModulePOMBuilder extends ModulePOMBuilder {
 
+	@Override
+	public void build(BWProject project, BWModule module) throws Exception {
+		
+		if(project.getType() == BWProjectType.SharedModule){
+			if (!module.isOverridePOM()) {
+				return;
+			}
+			
+			this.project = project;
+			this.module = module;
+			this.bwEdition = "bw6";
+			
+			initializeModel();
+			addPrimaryTags();
+			addSecondaryTags();
+			addBuild();
+			if (module instanceof BWAppModule) {
+				addPaletteSharedDependency();
+			}
+			// addModuleDependencies();
+			if (module instanceof BWPluginModule && ((BWPluginModule) module).isCustomXpath()) {
+				addCustomXPathDependency();
+			}
+			// addProperties();
+			generatePOMFile();
+		}else{
+			super.build(project, module);
+		}
+	}
+	
+	protected void addSecondaryTags(){
+		model.setGroupId(module.getGroupId());
+		model.setVersion(module.getVersion());
+	}
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/tester/SharedModuleProjectTester.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/tester/SharedModuleProjectTester.java
@@ -1,0 +1,20 @@
+package com.tibco.bw.studio.maven.tester;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IProject;
+
+import com.tibco.bw.studio.maven.validation.ProjectUtils;
+
+public class SharedModuleProjectTester extends PropertyTester{
+
+	@Override
+	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+		if(receiver instanceof IProject){
+			IProject project = (IProject)receiver;
+			if(ProjectUtils.INSTANCE.isBWSharedModule(project)){
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/util/BW6MavenConstants.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/util/BW6MavenConstants.java
@@ -1,0 +1,17 @@
+package com.tibco.bw.studio.maven.util;
+
+import org.eclipse.core.runtime.QualifiedName;
+
+public class BW6MavenConstants {
+
+	public static final String MAVEN_NATURE_ID = "org.eclipse.m2e.core.maven2Nature"; //$NON-NLS-1$
+	public static final String POM_XML_LOCATION = "/pom.xml"; //$NON-NLS-1$
+	public static final String HEADER_BW_SHARED_MODULE = "TIBCO-BW-SharedModule"; //$NON-NLS-1$
+	public static final String HEADER_BW_SHARED_MODULE_VALUE = "META-INF/module.bwm"; //$NON-NLS-1$
+	public static final String HEADER_BUNDLE_NAME = "Bundle-SymbolicName"; //$NON-NLS-1$
+	
+	public static final String EXTERNAL_SM_URI_SCHEME = "zip:/?file:/"; //$NON-NLS-1$
+	
+	public static final QualifiedName PLUGIN_PROPERTY_EXTERNAL_SM = new QualifiedName("PLUGIN_ID", "SHARED_MODULE_TYPE"); //$NON-NLS-1$ //$NON-NLS-2$
+	public static final String PLUGIN_PROPERTY_VALUE_EXTERNAL_SM = "EXT_SM"; //$NON-NLS-1$
+}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/MavenDependenciesBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/MavenDependenciesBuilder.java
@@ -72,12 +72,6 @@ public class MavenDependenciesBuilder extends BWAbstractBuilder{
 		
 		for(Dependency dependency : dependencyList){
 			
-//			String dependencyId = dependency.getGroupId() + "." + dependency.getArtifactId();
-//			String version = dependency.getVersion();
-//			if(isDependencyCreated(dependencyId, version)){
-//				continue;
-//			}
-			
 			File jarFile = getDependencyFile(dependency);
 			if(isSharedModule(jarFile)){
 				jarDependencies.add(jarFile);
@@ -87,7 +81,9 @@ public class MavenDependenciesBuilder extends BWAbstractBuilder{
 		List<IProject> projects = new ArrayList<IProject>();
 		for(File file : jarDependencies){
 			IProject p = createProjectFromJar(file);
-			projects.add(p);
+			if(p != null){
+				projects.add(p);
+			}
 		}
 		
 		addModulesToProjectDependencies(projects, project);

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/MavenDependenciesBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/MavenDependenciesBuilder.java
@@ -26,6 +26,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.m2e.core.embedder.IMaven;
@@ -232,6 +233,7 @@ public class MavenDependenciesBuilder extends BWAbstractBuilder{
 				jarProject.create(desc , progressMonitor);
 				jarProject.open(progressMonitor);
 				jarProject.setPersistentProperty(PDECore.EXTERNAL_PROJECT_PROPERTY, PDECore.BINARY_PROJECT_VALUE);
+				jarProject.setPersistentProperty(new QualifiedName("PLUGIN_ID", "SHARED_MODULE_TYPE"), "EXT_SM"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 									
 //				XpdProjectResourceFactory factory = XpdResourcesPlugin.getDefault().getXpdProjectResourceFactory(jarProject);
 				

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/MavenDependenciesBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/MavenDependenciesBuilder.java
@@ -1,0 +1,272 @@
+package com.tibco.bw.studio.maven.validation;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IProjectNature;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.embedder.IMavenConfiguration;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
+import org.eclipse.m2e.core.internal.preferences.MavenConfigurationImpl;
+import org.eclipse.pde.internal.core.PDECore;
+
+import com.tibco.bw.design.api.BWAbstractBuilder;
+import com.tibco.bw.design.util.ModelHelper;
+import com.tibco.bw.studio.maven.helpers.POMHelper;
+import com.tibco.xpd.resources.XpdProjectResourceFactory;
+import com.tibco.xpd.resources.XpdResourcesPlugin;
+
+public class MavenDependenciesBuilder extends BWAbstractBuilder{
+	
+	protected IMaven maven;
+	
+	protected static Map<String, String> dependenciesMap;
+	
+	public static final String MAVEN_NATURE_ID = "org.eclipse.m2e.core.maven2Nature";
+	
+	@Override
+	public void doBuild(int kind, IProject project, IProgressMonitor monitor) {
+				
+		if(project == null){
+			return;
+		}
+		
+		if(!isMavenProject(project)){
+			return;
+		}
+			
+		if(!isLocalProject(project)){
+			return;
+		}
+		
+		File pomFileAbs = getPOMFile(project);
+
+		if(pomFileAbs == null || !pomFileAbs.exists()){
+			return;
+		}
+		
+		Model mavenModel = POMHelper.readModelFromPOM(pomFileAbs);
+		List<Dependency> dependencyList = mavenModel.getDependencies();
+		List<File> jarDependencies = new ArrayList<File>();
+		
+		for(Dependency dependency : dependencyList){
+			
+//			String dependencyId = dependency.getGroupId() + "." + dependency.getArtifactId();
+//			String version = dependency.getVersion();
+//			if(isDependencyCreated(dependencyId, version)){
+//				continue;
+//			}
+			
+			File jarFile = getDependencyFile(dependency);
+			if(isSharedModule(jarFile)){
+				jarDependencies.add(jarFile);
+			}
+		}
+		
+		List<IProject> projects = new ArrayList<IProject>();
+		for(File file : jarDependencies){
+			IProject p = createProjectFromJar(file);
+			projects.add(p);
+		}
+		
+		addModulesToProjectDependencies(projects, project);
+		
+	}
+	
+	protected boolean isLocalProject(IProject project){
+		boolean isLocal = true;
+		
+		try {
+			String value = project.getPersistentProperty(PDECore.EXTERNAL_PROJECT_PROPERTY);
+			if(value != null){
+				isLocal = false;
+			}
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+		
+		return isLocal;
+	}
+	
+	protected boolean isMavenProject(IProject project){
+		boolean isMavenProject = false;
+		try {
+			IProjectNature nature = project.getNature(MAVEN_NATURE_ID);
+			if(nature != null){
+				isMavenProject = true;
+			}
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+		
+		return isMavenProject;
+	}
+	
+	protected File getPOMFile(IProject project){
+		IFile pomFile = project.getFile("/pom.xml");
+		
+		if(!pomFile.exists()){
+			return null;
+		}
+		
+		return pomFile.getRawLocation().toFile();
+	}
+	
+	protected File getDependencyFile(Dependency dependency){
+		if(maven == null){
+			IMavenConfiguration config = new MavenConfigurationImpl();
+			maven = new MavenImpl(config);
+		}
+		try {
+			String groupId = dependency.getGroupId();
+			String artifactId = dependency.getArtifactId();
+			String version = dependency.getVersion();
+			String type = dependency.getType();
+			String classifier = dependency.getClassifier();
+			
+			Artifact artifact = maven.resolve(groupId, artifactId, version, type, classifier, maven.getArtifactRepositories(), null);
+			if(artifact != null){
+				File f = artifact.getFile();
+				if(f.exists() && f.isFile()){
+					return f;
+				}
+			}
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+		
+		return null;
+	}
+	
+	protected boolean isSharedModule(File file){
+		if(file != null){
+			try {
+				JarFile jarFile = new JarFile(file);
+				Manifest manifest = jarFile.getManifest();
+				if(manifest != null){	
+					Attributes attr = manifest.getMainAttributes();
+					String value = attr.getValue("TIBCO-BW-SharedModule");
+					jarFile.close();
+					if(value != null && value.equals("META-INF/module.bwm")){
+						return true;
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+				return false;
+			}
+		}
+		return false;
+	}
+
+	protected boolean isDependencyCreated(String dependencyID, String version){
+		if(dependenciesMap == null){
+			dependenciesMap = new HashMap<String, String>();
+			return false;
+		}else{
+			String key = dependencyID + "-" + version;
+			if(dependenciesMap.containsKey(key)){
+				String projectName = dependenciesMap.get(key);
+				IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+				if(project.exists()){
+					return true;
+				}
+			}
+		}
+		
+		return false;
+	}
+
+	protected IProject createProjectFromJar(File jarFile){
+		if(jarFile == null){
+			return null;
+		}
+		//For TEST ONLY
+		String p1 = "C:/BW/extSM-1.0.0.jar";
+		jarFile = new File(p1);
+    	
+		String projectName = getProjectName(jarFile);
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		IProject jarProject = root.getProject(projectName);
+		
+		if(jarProject.exists()){
+			return null;
+		}
+		
+		String location = jarFile.toPath().toString();
+		IPath jarPath = new Path(location);
+		
+	    if("jar".equalsIgnoreCase(jarPath.getFileExtension())){
+	    	try {
+                String path = jarFile.getAbsolutePath();
+                path = path.replace("\\", "/");
+                URI zipURI = new URI("zip:/?file:/" + path);
+                
+                IProjectDescription desc = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+                desc.setLocationURI(zipURI);
+
+				IProgressMonitor progressMonitor = new NullProgressMonitor();
+				jarProject.create(desc , progressMonitor);
+				jarProject.open(progressMonitor);
+				jarProject.setPersistentProperty(PDECore.EXTERNAL_PROJECT_PROPERTY, PDECore.BINARY_PROJECT_VALUE);
+									
+				XpdProjectResourceFactory factory = XpdResourcesPlugin.getDefault().getXpdProjectResourceFactory(jarProject);
+				
+				return jarProject;
+	    	}catch(Exception e){
+	    		e.printStackTrace();
+	    	}
+	    }
+	    
+	    return null;
+	}
+
+	protected String getProjectName(File file){
+		String projectName = "";
+		if(file != null){
+			try {
+				JarFile jarFile = new JarFile(file);
+				Manifest manifest = jarFile.getManifest();
+				if(manifest != null){	
+					Attributes attr = manifest.getMainAttributes();
+					String value = attr.getValue("Bundle-SymbolicName"); //$NON-NLS-1$
+					jarFile.close();
+					if(value != null ){
+						 projectName = value;
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		return projectName;
+	}
+
+	
+	protected void addModulesToProjectDependencies(List<IProject> modules, IProject sourceProject){
+		for(IProject module : modules){
+			ModelHelper.INSTANCE.addModuleProvideCapabilities(module, sourceProject);
+		}
+	}
+}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/ProjectUtils.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/ProjectUtils.java
@@ -1,0 +1,40 @@
+package com.tibco.bw.studio.maven.validation;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.pde.internal.core.bundle.WorkspaceBundlePluginModel;
+import org.eclipse.pde.internal.core.ibundle.IBundle;
+import org.eclipse.pde.internal.core.project.PDEProject;
+
+import com.tibco.bw.design.util.BWDesignConstants;
+
+public class ProjectUtils {
+
+	public static ProjectUtils INSTANCE = new ProjectUtils();
+	
+	private ProjectUtils(){}
+	
+	public boolean isBWSharedModule(IProject project) {
+		if (project != null) {
+			IFile pluginXml = PDEProject.getPluginXml(project);
+			IFile manifest = PDEProject.getManifest(project);
+			WorkspaceBundlePluginModel bundlePluginModel = new WorkspaceBundlePluginModel(manifest, pluginXml);
+			if (bundlePluginModel.getBundleModel() != null) {
+				IBundle bundle = bundlePluginModel.getBundleModel().getBundle();
+				return isBWSharedModule(bundle);
+			}
+		}
+		return false;
+	}
+	
+	public boolean isBWSharedModule(IBundle bundle) {
+		if (bundle != null) {
+			String headerValue = bundle.getHeader(BWDesignConstants.TIBCO_BW_SHARED_MODULE_HEADER);
+			if (headerValue != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
The following changes provide the basic functionality for:
a) Exporting BW Shared Modules as independent artifacts to the maven repository
b) Enabling BW Shared Module artifacts as dependencies for Application Modules
c) Using BW Shared Module artifact resources in Application Modules
