### PR TITLE
Enhancement to add Auto Pull for Docker Base Image (#105)

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWDockerModule.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWDockerModule.java
@@ -13,6 +13,8 @@ public class BWDockerModule {
 	
 	private String dockerImageFrom;
 	
+	private boolean autoPullImage;
+	
 	private String dockerImageMaintainer;
 	
 	private String dockerAppName;
@@ -59,6 +61,14 @@ public class BWDockerModule {
 
 	public void setDockerImageFrom(String dockerImageFrom) {
 		this.dockerImageFrom = dockerImageFrom;
+	}
+	
+	public boolean isAutoPullImage() {
+		return autoPullImage;
+	}
+
+	public void setAutoPullImage(boolean autoPullImage) {
+		this.autoPullImage = autoPullImage;
 	}
 
 	public String getDockerImageMaintainer() {
@@ -122,6 +132,8 @@ public class BWDockerModule {
 	public void setPlatform(String platform) {
 		this.platform = platform;
 	}
+
+	
 
 
 	

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWDockerModule.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWDockerModule.java
@@ -68,7 +68,7 @@ public class BWDockerModule {
 	}
 
 	public void setAutoPullImage(boolean autoPullImage) {
-		this.autoPullImage = autoPullImage;
+		this.autoPullImage= autoPullImage;
 	}
 
 	public String getDockerImageMaintainer() {

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -296,9 +296,11 @@ public abstract class AbstractPOMBuilder {
 		config.addChild(child);
 		
 		
-		child = new Xpp3Dom("autoPull");
+		child = new Xpp3Dom("imagePullPolicy");
+		
 		child.setValue("${bwdocker.autoPullImage}");
 		config.addChild(child);
+		
 
 		child = new Xpp3Dom("dockerHost");
 		child.setValue("${bwdocker.host}");
@@ -511,7 +513,7 @@ public abstract class AbstractPOMBuilder {
 			properties.setProperty("docker.image", module.getBwDockerModule().getDockerImageName());
 			properties.setProperty("bwdocker.containername", module.getBwDockerModule().getDockerAppName());
 			properties.setProperty("bwdocker.from", module.getBwDockerModule().getDockerImageFrom());
-			properties.setProperty("bwdocker.autoPullImage", (module.getBwDockerModule().isAutoPullImage()?"true":"false"));
+			properties.setProperty("bwdocker.autoPullImage", (module.getBwDockerModule().isAutoPullImage()?"Always":"IfNotPresent"));
 			properties.setProperty("bwdocker.maintainer", module.getBwDockerModule().getDockerImageMaintainer());
 			
 

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -294,13 +294,7 @@ public abstract class AbstractPOMBuilder {
 		Xpp3Dom child = new Xpp3Dom("skip");
 		child.setValue("false");
 		config.addChild(child);
-		
-		
-		child = new Xpp3Dom("imagePullPolicy");
-		
-		child.setValue("${bwdocker.autoPullImage}");
-		config.addChild(child);
-		
+				
 
 		child = new Xpp3Dom("dockerHost");
 		child.setValue("${bwdocker.host}");
@@ -323,6 +317,10 @@ public abstract class AbstractPOMBuilder {
 		Xpp3Dom buildchild = new Xpp3Dom("build");
 		Xpp3Dom child2 = new Xpp3Dom("from");
 		child2.setValue("${bwdocker.from}");
+		buildchild.addChild(child2);
+		
+		child2 = new Xpp3Dom("imagePullPolicy");
+		child2.setValue("${bwdocker.autoPullImage}");
 		buildchild.addChild(child2);
 
 		child2 = new Xpp3Dom("maintainer");

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -294,6 +294,11 @@ public abstract class AbstractPOMBuilder {
 		Xpp3Dom child = new Xpp3Dom("skip");
 		child.setValue("false");
 		config.addChild(child);
+		
+		
+		child = new Xpp3Dom("autoPull");
+		child.setValue("${bwdocker.autoPullImage}");
+		config.addChild(child);
 
 		child = new Xpp3Dom("dockerHost");
 		child.setValue("${bwdocker.host}");
@@ -506,7 +511,9 @@ public abstract class AbstractPOMBuilder {
 			properties.setProperty("docker.image", module.getBwDockerModule().getDockerImageName());
 			properties.setProperty("bwdocker.containername", module.getBwDockerModule().getDockerAppName());
 			properties.setProperty("bwdocker.from", module.getBwDockerModule().getDockerImageFrom());
+			properties.setProperty("bwdocker.autoPullImage", (module.getBwDockerModule().isAutoPullImage()?"true":"false"));
 			properties.setProperty("bwdocker.maintainer", module.getBwDockerModule().getDockerImageMaintainer());
+			
 
 			List<String> volumes = module.getBwDockerModule().getDockerVolumes();
 			if(volumes != null && volumes.size() > 0) {

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageDocker.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageDocker.java
@@ -168,7 +168,7 @@ public class WizardPageDocker extends WizardPage {
 		dockerImageFrom.setLayoutData(imgFromData);
 		
 		Label autoPullLabel = new Label(container, SWT.NONE);
-		autoPullLabel.setText("Auto Pull Base Image");
+		autoPullLabel.setText("Auto Pull Images");
 		GridData autoPullData = new GridData(50, 15);
 		autoPullImage= new Button(container, SWT.CHECK);
 		autoPullImage.setSelection(false);

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageDocker.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageDocker.java
@@ -168,7 +168,7 @@ public class WizardPageDocker extends WizardPage {
 		dockerImageFrom.setLayoutData(imgFromData);
 		
 		Label autoPullLabel = new Label(container, SWT.NONE);
-		autoPullLabel.setText("Auto Pull Images");
+		autoPullLabel.setText("Auto Pull Base Image");
 		GridData autoPullData = new GridData(50, 15);
 		autoPullImage= new Button(container, SWT.CHECK);
 		autoPullImage.setSelection(false);

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageDocker.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageDocker.java
@@ -31,6 +31,8 @@ public class WizardPageDocker extends WizardPage {
 	private Text dockerHostCertPath;
 	private Text dockerImageName;
 	private Text dockerImageFrom;
+	private Button autoPullImage;
+	private boolean isAutoPull;
 	private Text dockerImageMaintainer;
 	private Text dockerAppName;
 	private Text dockerVolume;
@@ -164,6 +166,33 @@ public class WizardPageDocker extends WizardPage {
 		dockerImageFrom.setText("tibco/bwce");
 		GridData imgFromData = new GridData(100, 15);
 		dockerImageFrom.setLayoutData(imgFromData);
+		
+		Label autoPullLabel = new Label(container, SWT.NONE);
+		autoPullLabel.setText("Auto Pull Base Image");
+		GridData autoPullData = new GridData(50, 15);
+		autoPullImage= new Button(container, SWT.CHECK);
+		autoPullImage.setSelection(false);
+		autoPullImage.setLayoutData(autoPullData);
+		autoPullImage.addSelectionListener(new SelectionListener(){
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if(autoPullImage.getSelection()){
+					isAutoPull= true;
+				}
+				else{
+					isAutoPull= false;
+				}
+				
+			}
+
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+				
+				
+			}
+			
+		});
 
 		Label maintainerLabel = new Label(container, SWT.NONE);
 		maintainerLabel.setText("Maintainer");
@@ -171,10 +200,17 @@ public class WizardPageDocker extends WizardPage {
 		dockerImageMaintainer = new Text(container, SWT.BORDER | SWT.SINGLE);
 		dockerImageMaintainer.setText("abc@tibco.com");
 		GridData maintainerData = new GridData(200, 15);
-		maintainerData.horizontalSpan = 3;
-		dockerImageMaintainer.setLayoutData(maintainerData);
 
-		final Button dkr = new Button(container, SWT.CHECK);
+		dockerImageMaintainer.setLayoutData(maintainerData);
+		
+		
+		Composite innerContainer = new Composite(container, SWT.NONE);
+
+		GridLayout layout = new GridLayout();
+		innerContainer.setLayout(layout);
+		layout.numColumns = 2;
+		final Button dkr = new Button(innerContainer, SWT.CHECK);
+		
 		dkr.setSelection(false);
 
 		dkr.addSelectionListener(new SelectionListener() {
@@ -208,9 +244,11 @@ public class WizardPageDocker extends WizardPage {
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 		});
-
-		Label dkrlabel = new Label(container, SWT.NONE);
+		
+		
+		Label dkrlabel = new Label(innerContainer, SWT.NONE);
 		dkrlabel.setText("Run on docker host");
+		
 		// createContents(container);
 	}
 
@@ -278,6 +316,8 @@ public class WizardPageDocker extends WizardPage {
 		bwdocker.setDockerHostCertPath(dockerHostCertPath.getText());
 		bwdocker.setDockerImageName(dockerImageName.getText());
 		bwdocker.setDockerImageFrom(dockerImageFrom.getText());
+		
+		bwdocker.setAutoPullImage(isAutoPull);
 		bwdocker.setDockerImageMaintainer(dockerImageMaintainer.getText());
 
 		// Below are Docker Run values - set them only if checked otherwise blank


### PR DESCRIPTION
Description: An Auto-Pull option is added to pull the docker images with the latest version from a remote repository. This checkbox is added next to the Image name fields in the POM Generation UI Docker wizard. If checked, the docker maven plugin attempts to always pull the latest base image during building an image. This option should be used only if the base image is available in a remote repository.

Code Changes: Design time changes in Studio Maven Plugin, related to addition of a new property 'bwdocker.autoPullImage' in the docker properties file. This property will then be included in the 'imagePullPolicy' tag, under the Docker-Maven-Plugin configuration in the generated POM. ImagePullPolicy tag has been used as its functionality is equivalent to that of autoPull since the autoPull tag is deprecated according to https://dmp.fabric8.io .

Issue resolved by the Pull Request:  https://github.com/TIBCOSoftware/bw6-plugin-maven/issues/105

The checkbox added at the docker page is as follows:  
![docker](https://user-images.githubusercontent.com/21974930/44644619-62d36100-a9f2-11e8-950a-f303c5355355.jpg)


