### PR TITLE
Enhancement,Added feature- Using profiles in Maven Deployment command #34

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
@@ -104,6 +104,15 @@ public class BWEARInstallerMojo extends AbstractMojo {
 	@Parameter(property="backup")
 	private boolean backup;
 
+	@Parameter(property="externalProfile")
+	private boolean externalProfile;
+	
+	@Parameter(property="externalProfileLoc")
+	private String externalProfileLoc;
+	
+	@Parameter(property="version")
+	private String version;
+	
 	@Parameter(property="backupLocation")
 	private String backupLocation;
 
@@ -158,7 +167,7 @@ public class BWEARInstallerMojo extends AbstractMojo {
         		agentName = agent.getName();
         		getLog().info("Agent Name -> " + agentName);
         	}
-
+        	version=manifest.getMainAttributes().getValue("Manifest-Version");
     		deployer.getOrCreateDomain(domain, domainDesc);
     		AppSpace appSpaceDto = deployer.getOrCreateAppSpace(domain, appSpace, appSpaceDesc);
     		deployer.getOrCreateAppNode(domain, appSpace, appNode, Integer.parseInt(httpPort), osgiPort == null || osgiPort.isEmpty() ? -1 : Integer.parseInt(osgiPort), appNodeDesc, agentName);
@@ -168,7 +177,7 @@ public class BWEARInstallerMojo extends AbstractMojo {
     			getLog().info("AppSpace is Running.");
     		}
     		getLog().info("domain -> " + domain + " earName -> " + earName + " Ear file to be uploaded -> " + files[0].getAbsolutePath());
-    		deployer.addAndDeployApplication(domain, appSpace, applicationName, earName, files[0].getAbsolutePath(), redeploy, profile, backup, backupLocation);
+    		deployer.addAndDeployApplication(domain, appSpace, applicationName, earName, files[0].getAbsolutePath(), redeploy, profile, backup, backupLocation,version,externalProfile,externalProfileLoc);
     		deployer.close();
     	} catch(Exception e) {
     		getLog().error(e);
@@ -239,6 +248,8 @@ public class BWEARInstallerMojo extends AbstractMojo {
 			redeploy = Boolean.parseBoolean(deployment.getProperty("redeploy"));
 			backup = Boolean.parseBoolean(deployment.getProperty("backup"));
 			backupLocation = deployment.getProperty("backupLocation");
+			externalProfile=Boolean.parseBoolean(deployment.getProperty("externalProfile"));
+			externalProfileLoc=deployment.getProperty("externalProfileLoc");
 		} catch(Exception e) {
 			deployToAdmin = false;
 			getLog().error(e);
@@ -315,6 +326,12 @@ public class BWEARInstallerMojo extends AbstractMojo {
 			isValidBackupLoc = false;
 			errorMessage.append("[Backup Location value is required]");
 		}
+		
+		boolean isValidexternalProfileLoc = true;
+		if(externalProfile && externalProfileLoc.isEmpty()) {
+			isValidexternalProfileLoc = false;
+			errorMessage.append("[external Profile Location value is required]");
+		}
 
 		boolean isValidCredential = true;
 		if(agentAuth != null && (Constants.BASIC_AUTH.equalsIgnoreCase(agentAuth) || Constants.DIGEST_AUTH.equalsIgnoreCase(agentAuth))) {
@@ -345,7 +362,7 @@ public class BWEARInstallerMojo extends AbstractMojo {
 			return false;
 		}
 
-		if(isValidHost && isValidPort && isValidDomain && isValidAppSpace && isValidAppNode && isValidHTTPPort && isValidOSGi && isValidBackupLoc && isValidCredential && isValidSSL) {
+		if(isValidHost && isValidPort && isValidDomain && isValidAppSpace && isValidAppNode && isValidHTTPPort && isValidOSGi && isValidBackupLoc && isValidCredential && isValidSSL && isValidexternalProfileLoc) {
 			return true;
 		}
 		return false;

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWDeploymentInfo.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWDeploymentInfo.java
@@ -24,9 +24,11 @@ public class BWDeploymentInfo {
 	private String httpPort = "";
 	private String osgiPort = "";
 	private String profile = "";
-	private boolean redeploy = true;
-	private boolean backup = true;
+	private boolean redeploy = false;
+	private boolean backup = false;
 	private String backupLocation = "";
+	private boolean externalProfile = false;
+	private String externalProfileLoc = "";
 	private List<String> profiles = new ArrayList<String>();
 
 	public boolean isDeployToAdmin() {
@@ -156,7 +158,22 @@ public class BWDeploymentInfo {
 	public void setBackupLocation(String backupLocation) {
 		this.backupLocation = backupLocation;
 	}
+	public boolean isexternalProfile() {
+		return externalProfile;
+	}
 
+	public void setexternalProfile(boolean externalProfile) {
+		this.externalProfile = externalProfile;
+	}
+
+	public String getexternalProfileLoc() {
+		return externalProfileLoc;
+	}
+
+	public void setexternalProfileLoc(String externalProfileLoc) {
+		this.externalProfileLoc = externalProfileLoc;
+	}
+	
 	public String getAgentUsername() {
 		return agentUsername;
 	}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
@@ -145,6 +145,8 @@ public class ApplicationPOMBuilder extends AbstractPOMBuilder implements IPOMBui
 			model.getProperties().remove("backup");
 			model.getProperties().remove("backupLocation");
 			model.getProperties().remove("profile");
+			model.getProperties().remove("externalProfile");
+			model.getProperties().remove("externalProfileLoc");
 			return;
 		}
 
@@ -266,6 +268,16 @@ public class ApplicationPOMBuilder extends AbstractPOMBuilder implements IPOMBui
 		model.addProperty("backupLocation", info.getBackupLocation());
 		properties.put("backupLocation", info.getBackupLocation());
 
+		Xpp3Dom externalProfile  = new Xpp3Dom("externalProfile");
+		externalProfile.setValue("${externalProfile}");
+		model.addProperty("externalProfile", Boolean.toString(info.isexternalProfile()));
+		properties.put("externalProfile", Boolean.toString(info.isexternalProfile()));
+
+		Xpp3Dom externalProfileLoc  = new Xpp3Dom("externalProfileLoc");
+		externalProfileLoc.setValue("${externalProfileLoc}");
+		model.addProperty("externalProfileLoc", info.getexternalProfileLoc());
+		properties.put("externalProfileLoc", info.getexternalProfileLoc());
+		
 		config.addChild(deployToAdmin);
 		config.addChild(agentHost);
 		config.addChild(agentPort);
@@ -289,6 +301,8 @@ public class ApplicationPOMBuilder extends AbstractPOMBuilder implements IPOMBui
 		config.addChild(backup);
 		config.addChild(backupLocation);
 		config.addChild(profile);
+		config.addChild(externalProfile);
+		config.addChild(externalProfileLoc);
 
 		plugin.setConfiguration(config);
 


### PR DESCRIPTION
 **Design time changes**- I have added a option of "other" to the combo box field named "profile" in pom generation wizard page..When user selects this option another new text box which is added named "external profile location" gets enabled.After adding external profile with its path to the text box,pom gets generated with new xml elements added named "externalProfileLoc" ,"externalProfile" with the respective values. 
                                 Apart from this, I have set "backup location" text box by default disabled(which should only be enabled when backup checkbox is selected),which was a defect.Also I have changed grid data size of other fields backup,backup location,redeployment for its proper visibility on all machines. 

**Runtime changes**- The external profile path is read from deployment config file.During deployment the BWInstallerMojo will set profile using RemoteDeployer which indirectly uploads the file using Jersey file upload mechanism and Rest API.

