### PR TITLE
Changes done for pom.xml is empty in project module

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -760,22 +760,17 @@ public abstract class AbstractPOMBuilder {
 	protected void initializeModel() {
 		File pomFile = module.getPomfileLocation();
 		model = readModel(pomFile);
-		if(model == null) {
-			model = new Model();
-		}
 	}
 
 	protected Model readModel(File pomXmlFile) {
 		Model model = null;
-		try {
-			Reader reader = new FileReader(pomXmlFile);
-			try {
-				MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
+		try (Reader reader = new FileReader(pomXmlFile)) {
+			MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
+			if (pomXmlFile.length() != 0)
 				model = xpp3Reader.read(reader);
-			} finally {
-				reader.close();
-			}
-		} catch(Exception e) {
+			else
+				model = new Model();
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 		return model;

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -26,6 +26,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import com.tibco.bw.studio.maven.helpers.ManifestParser;
 import com.tibco.bw.studio.maven.modules.model.BWApplication;
 import com.tibco.bw.studio.maven.modules.model.BWDeploymentInfo;
 import com.tibco.bw.studio.maven.modules.model.BWModule;
@@ -33,11 +34,13 @@ import com.tibco.bw.studio.maven.modules.model.BWModuleType;
 import com.tibco.bw.studio.maven.modules.model.BWPCFServicesModule;
 import com.tibco.bw.studio.maven.modules.model.BWParent;
 import com.tibco.bw.studio.maven.modules.model.BWProject;
+import com.tibco.bw.studio.maven.wizard.MavenWizardContext;
 
 public abstract class AbstractPOMBuilder {
 	protected BWProject project; 
 	protected BWModule module;
 	protected Model model;
+	protected static String bwEdition=null;
 
 	protected void addParent(BWParent parentModule) {
 		Parent parent = new Parent();
@@ -797,5 +800,48 @@ public abstract class AbstractPOMBuilder {
 			profiles.add(profile);
 		}
 		model.setProfiles(profiles);
+	}
+	protected static String setBwEdition(BWModule module)throws Exception{
+		Map<String, String> manifest = ManifestParser.parseManifest(module.getProject());
+		if (manifest.containsKey("TIBCO-BW-Edition") )				
+		{
+			String editions = manifest.get( "TIBCO-BW-Edition" );				
+			String[] editionList = editions.split(",");
+				for( String str : editionList )
+				{
+					switch ( str )
+					{
+					case "bwe":
+						bwEdition = "bw6";
+						break;
+
+					case "bwcf":
+						
+							switch ( MavenWizardContext.INSTANCE.getSelectedType() )
+							{
+							case PCF:
+								bwEdition = "cf";
+								break;
+								
+							case Docker:
+								bwEdition = "docker";
+								break;
+							
+							case None:
+								bwEdition = "bw6";
+								break;
+								
+							default:
+								break;
+							}
+						
+						break;
+				default:
+						break;
+					}
+					
+				}
+		}
+		return bwEdition;
 	}
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
@@ -61,6 +61,10 @@ public class ApplicationPOMBuilder extends AbstractPOMBuilder implements IPOMBui
 								bwEdition = "docker";
 								break;
 							
+							case None:
+								bwEdition = "bw6";
+								break;
+								
 							default:
 								break;
 							}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
@@ -34,48 +34,7 @@ public class ApplicationPOMBuilder extends AbstractPOMBuilder implements IPOMBui
 
 		this.project = project;
 		this.module = module;
-		
-		Map<String, String> manifest = ManifestParser.parseManifest(module.getProject());
-		if (manifest.containsKey("TIBCO-BW-Edition") )				
-		{
-			String editions = manifest.get( "TIBCO-BW-Edition" );				
-	
-				String[] editionList = editions.split(",");
-				for( String str : editionList )
-				{
-					switch ( str )
-					{
-					case "bwe":
-						bwEdition = "bw6";
-						break;
-
-					case "bwcf":
-						
-							switch ( MavenWizardContext.INSTANCE.getSelectedType() )
-							{
-							case PCF:
-								bwEdition = "cf";
-								break;
-								
-							case Docker:
-								bwEdition = "docker";
-								break;
-							
-							case None:
-								bwEdition = "bw6";
-								break;
-								
-							default:
-								break;
-							}
-						
-						break;
-				default:
-						break;
-					}
-					
-				}
-		}
+		bwEdition=setBwEdition(module);
 		initializeModel();
 		addPrimaryTags();
 		//addParent(ModuleHelper.getParentModule(project.getModules()));

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
@@ -26,47 +26,7 @@ public class ModulePOMBuilder extends AbstractPOMBuilder implements IPOMBuilder 
 		}
 		this.project = project;
 		this.module = module;
-
-		Map<String, String> manifest = ManifestParser.parseManifest(module
-				.getProject());
-		if (manifest.containsKey("TIBCO-BW-Edition")) {
-			String editions = manifest.get("TIBCO-BW-Edition");
-
-			String[] editionList = editions.split(",");
-			for (String str : editionList) {
-				switch (str) {
-				case "bwe":
-					bwEdition = "bw6";
-					break;
-
-				case "bwcf":
-
-					switch (MavenWizardContext.INSTANCE.getSelectedType()) {
-					case PCF:
-						bwEdition = "cf";
-						break;
-
-					case Docker:
-						bwEdition = "docker";
-						break;
-
-					case None:
-						bwEdition = "bw6";
-						break;
-
-					default:
-						break;
-					}
-
-					break;
-				default:
-
-					break;
-				}
-
-			}
-		}
-
+		bwEdition=setBwEdition(module);
 		initializeModel();
 		addPrimaryTags();
 		addParent(ModuleHelper.getParentModule(project.getModules()));

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
@@ -14,6 +14,7 @@ import com.tibco.bw.studio.maven.modules.model.BWModule;
 import com.tibco.bw.studio.maven.modules.model.BWModuleType;
 import com.tibco.bw.studio.maven.modules.model.BWPluginModule;
 import com.tibco.bw.studio.maven.modules.model.BWProject;
+import com.tibco.bw.studio.maven.wizard.MavenWizardContext;
 
 public class ModulePOMBuilder extends AbstractPOMBuilder implements IPOMBuilder {
 	protected String bwEdition;
@@ -26,16 +27,45 @@ public class ModulePOMBuilder extends AbstractPOMBuilder implements IPOMBuilder 
 		this.project = project;
 		this.module = module;
 
-		Map<String, String> manifest = ManifestParser.parseManifest(module.getProject());
-		if (manifest.containsKey("TIBCO-BW-Edition") && manifest.get("TIBCO-BW-Edition").equals("bwcf")) {
-			String targetPlatform = "docker";
-			if (targetPlatform.equals("Cloud Foundry")) {
-				bwEdition = "cf";
-			} else {
-				bwEdition = "docker";
+		Map<String, String> manifest = ManifestParser.parseManifest(module
+				.getProject());
+		if (manifest.containsKey("TIBCO-BW-Edition")) {
+			String editions = manifest.get("TIBCO-BW-Edition");
+
+			String[] editionList = editions.split(",");
+			for (String str : editionList) {
+				switch (str) {
+				case "bwe":
+					bwEdition = "bw6";
+					break;
+
+				case "bwcf":
+
+					switch (MavenWizardContext.INSTANCE.getSelectedType()) {
+					case PCF:
+						bwEdition = "cf";
+						break;
+
+					case Docker:
+						bwEdition = "docker";
+						break;
+
+					case None:
+						bwEdition = "bw6";
+						break;
+
+					default:
+						break;
+					}
+
+					break;
+				default:
+
+					break;
+				}
+
 			}
-		} else
-			bwEdition = "bw6";
+		}
 
 		initializeModel();
 		addPrimaryTags();

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
@@ -62,7 +62,7 @@ public class WizardPageConfiguration extends WizardPage {
 	public WizardPageConfiguration(String pageName, BWProject project) {
 		super(pageName);
 		this.project = project;
-		setTitle("Maven Configuration Details for Plugin Code for Apache Maven and TIBCO BusinessWorks");
+		setTitle("Maven Configuration Details for Plugin Code for Apache Maven and TIBCO BusinessWorks(TM)");
 		if(project.getType() == BWProjectType.Application){
 			setDescription("Enter the GroupId and ArtifactId for Maven POM File generation.\nPOM files will be generated for Projects listed below and Parent POM file will be generated aggregating the Projects");
 


### PR DESCRIPTION
****What's this Pull request about?
      The pull request about the solution for the issue #186 pom.xml file is empty in project module 
      and issue #2 BW6 Maven plugin Generate POM dialog text is not visible.
 
 ****Which Issue(s) this Pull Request will fix?
     The pull request will fix issue #186 pom.xml file is empty in the project module.
     and issue#2 BW6 Maven plugin Generate POM dialog text is not visible.
 
 ****Does this pull request maintain backward compatibility?
        yes
 
 ****How this pull request has been tested?
	1) Create new application module with target platform container. Generate Pom with deployment 
            option None.
	2) Create a new Shared Module. Generate Pom.
	
 ****Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/40194420/45875033-25c17b00-bdb4-11e8-9429-847c7ea7287b.png)

 ****Any background context or comments you want to provide?
     I have created one new method setBwEdition in AbstractPOMBuilder.java file which returns BwEdition 
     value and modified method readModel in AbstractPOMBuilder.java file.
      Also, I have added TM in WizardPageConfiguration.java file.
 
  