### PR TITLE
#105 : Using imagePullPolicy label as autoPull is a deprecated property for Docker Images. 

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -298,10 +298,6 @@ public abstract class AbstractPOMBuilder {
 		child.setValue("false");
 		config.addChild(child);
 		
-		
-		child = new Xpp3Dom("autoPull");
-		child.setValue("${bwdocker.autoPullImage}");
-		config.addChild(child);
 
 		child = new Xpp3Dom("dockerHost");
 		child.setValue("${bwdocker.host}");
@@ -324,6 +320,10 @@ public abstract class AbstractPOMBuilder {
 		Xpp3Dom buildchild = new Xpp3Dom("build");
 		Xpp3Dom child2 = new Xpp3Dom("from");
 		child2.setValue("${bwdocker.from}");
+		buildchild.addChild(child2);
+		
+		child2 = new Xpp3Dom("imagePullPolicy");
+		child2.setValue("${bwdocker.autoPullImage}");
 		buildchild.addChild(child2);
 
 		child2 = new Xpp3Dom("maintainer");
@@ -514,7 +514,7 @@ public abstract class AbstractPOMBuilder {
 			properties.setProperty("docker.image", module.getBwDockerModule().getDockerImageName());
 			properties.setProperty("bwdocker.containername", module.getBwDockerModule().getDockerAppName());
 			properties.setProperty("bwdocker.from", module.getBwDockerModule().getDockerImageFrom());
-			properties.setProperty("bwdocker.autoPullImage", (module.getBwDockerModule().isAutoPullImage()?"true":"false"));
+			properties.setProperty("bwdocker.autoPullImage", (module.getBwDockerModule().isAutoPullImage()?"Always":"IfNotPresent"));
 			properties.setProperty("bwdocker.maintainer", module.getBwDockerModule().getDockerImageMaintainer());
 			
 


### PR DESCRIPTION

****What's this Pull request about?

Docker images can now be automatically pulled, if the 'Auto Pull Image' check box is selected in Docker Wizard page.

****Which Issue(s) this Pull Request will fix?

Add autoPull as option in Docker Wizard and POM [enhancement] #105


****Does this pull request maintain backward compatibility?

A new checkbox, and a new build tag is added in the POM files, which is used for the docker build goal. Hence backward compatibility is maintained, since this is new functionality. 

****How this pull request has been tested?

Tested that the docker image is pulled automatically ("Always" pull policy) if this checkbox is selected, and the image is pulled only if not present ("IfNotPresent" pull policy) if the checkbox is not selected.
