### PR TITLE
fix for issue #186 Changes done for pom.xml is empty in project module

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -397,7 +397,7 @@ public abstract class AbstractPOMBuilder {
 			Xpp3Dom envVarChild = new Xpp3Dom("envPropertyFile");
 			envVarChild.setValue("${docker.env.property.file}");
 			runchild.addChild(envVarChild);
-		}
+		} 
 		imageChild.addChild(runchild);
 		child.addChild(imageChild);
 		config.addChild(child);
@@ -768,18 +768,10 @@ public abstract class AbstractPOMBuilder {
 
 	protected Model readModel(File pomXmlFile) {
 		Model model = null;
-//		try {
-//			Reader reader = new FileReader(pomXmlFile);
-//			try {
-//				MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
 		try (Reader reader = new FileReader(pomXmlFile)) {
 			MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
 			if (pomXmlFile.length() != 0)
 				model = xpp3Reader.read(reader);
-//			} finally {
-//				reader.close();
-//			}
-//		} catch(Exception e) {
 			else
 				model = new Model();
 		} catch (Exception e) {

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -26,6 +26,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import com.tibco.bw.studio.maven.helpers.ManifestParser;
 import com.tibco.bw.studio.maven.modules.model.BWApplication;
 import com.tibco.bw.studio.maven.modules.model.BWDeploymentInfo;
 import com.tibco.bw.studio.maven.modules.model.BWModule;
@@ -33,11 +34,13 @@ import com.tibco.bw.studio.maven.modules.model.BWModuleType;
 import com.tibco.bw.studio.maven.modules.model.BWPCFServicesModule;
 import com.tibco.bw.studio.maven.modules.model.BWParent;
 import com.tibco.bw.studio.maven.modules.model.BWProject;
+import com.tibco.bw.studio.maven.wizard.MavenWizardContext;
 
 public abstract class AbstractPOMBuilder {
 	protected BWProject project; 
 	protected BWModule module;
 	protected Model model;
+	protected static String bwEdition=null;
 
 	protected void addParent(BWParent parentModule) {
 		Parent parent = new Parent();
@@ -760,22 +763,26 @@ public abstract class AbstractPOMBuilder {
 	protected void initializeModel() {
 		File pomFile = module.getPomfileLocation();
 		model = readModel(pomFile);
-		if(model == null) {
-			model = new Model();
-		}
+		
 	}
 
 	protected Model readModel(File pomXmlFile) {
 		Model model = null;
-		try {
-			Reader reader = new FileReader(pomXmlFile);
-			try {
-				MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
+//		try {
+//			Reader reader = new FileReader(pomXmlFile);
+//			try {
+//				MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
+		try (Reader reader = new FileReader(pomXmlFile)) {
+			MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
+			if (pomXmlFile.length() != 0)
 				model = xpp3Reader.read(reader);
-			} finally {
-				reader.close();
-			}
-		} catch(Exception e) {
+//			} finally {
+//				reader.close();
+//			}
+//		} catch(Exception e) {
+			else
+				model = new Model();
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 		return model;
@@ -802,5 +809,45 @@ public abstract class AbstractPOMBuilder {
 			profiles.add(profile);
 		}
 		model.setProfiles(profiles);
+	}
+
+	protected static String setBwEdition(BWModule module) throws Exception {
+		Map<String, String> manifest = ManifestParser.parseManifest(module
+				.getProject());
+		if (manifest.containsKey("TIBCO-BW-Edition")) {
+			String editions = manifest.get("TIBCO-BW-Edition");
+			String[] editionList = editions.split(",");
+			for (String str : editionList) {
+				switch (str) {
+				case "bwe":
+					bwEdition = "bw6";
+					break;
+				case "bwcf":
+
+					switch (MavenWizardContext.INSTANCE.getSelectedType()) {
+					case PCF:
+						bwEdition = "cf";
+						break;
+
+					case Docker:
+						bwEdition = "docker";
+						break;
+
+					case None:
+						bwEdition = "bw6";
+						break;
+
+					default:
+						break;
+					}
+
+					break;
+				default:
+					break;
+				}
+
+			}
+		}
+		return bwEdition;
 	}
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ApplicationPOMBuilder.java
@@ -34,44 +34,8 @@ public class ApplicationPOMBuilder extends AbstractPOMBuilder implements IPOMBui
 
 		this.project = project;
 		this.module = module;
-		
-		Map<String, String> manifest = ManifestParser.parseManifest(module.getProject());
-		if (manifest.containsKey("TIBCO-BW-Edition") )				
-		{
-			String editions = manifest.get( "TIBCO-BW-Edition" );				
-	
-				String[] editionList = editions.split(",");
-				for( String str : editionList )
-				{
-					switch ( str )
-					{
-					case "bwe":
-						bwEdition = "bw6";
-						break;
 
-					case "bwcf":
-						
-							switch ( MavenWizardContext.INSTANCE.getSelectedType() )
-							{
-							case PCF:
-								bwEdition = "cf";
-								break;
-								
-							case Docker:
-								bwEdition = "docker";
-								break;
-							
-							default:
-								break;
-							}
-						
-						break;
-				default:
-						break;
-					}
-					
-				}
-		}
+		bwEdition = setBwEdition(module);
 		initializeModel();
 		addPrimaryTags();
 		//addParent(ModuleHelper.getParentModule(project.getModules()));

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ModulePOMBuilder.java
@@ -26,17 +26,7 @@ public class ModulePOMBuilder extends AbstractPOMBuilder implements IPOMBuilder 
 		this.project = project;
 		this.module = module;
 
-		Map<String, String> manifest = ManifestParser.parseManifest(module.getProject());
-		if (manifest.containsKey("TIBCO-BW-Edition") && manifest.get("TIBCO-BW-Edition").equals("bwcf")) {
-			String targetPlatform = "docker";
-			if (targetPlatform.equals("Cloud Foundry")) {
-				bwEdition = "cf";
-			} else {
-				bwEdition = "docker";
-			}
-		} else
-			bwEdition = "bw6";
-
+		bwEdition = setBwEdition(module);
 		initializeModel();
 		addPrimaryTags();
 		addParent(ModuleHelper.getParentModule(project.getModules()));

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
@@ -1,8 +1,13 @@
 package com.tibco.bw.studio.maven.wizard;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.eclipse.core.internal.resources.Project;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -368,7 +373,11 @@ public class WizardPageConfiguration extends WizardPage {
 		groupLabel.setText("Group Id:");
 
 		appGroupId = new Text(innerContainer, SWT.BORDER | SWT.SINGLE);
-		appGroupId.setText(module.getGroupId());
+		File pomFile = module.getPomfileLocation();
+		if(readModel(pomFile).getGroupId() != null)
+			appGroupId.setText(readModel(pomFile).getGroupId());
+		else
+			appGroupId.setText(module.getGroupId());
 		GridData groupData = new GridData(200, 15);
 		appGroupId.setLayoutData(groupData);
 
@@ -398,6 +407,20 @@ public class WizardPageConfiguration extends WizardPage {
 //		versionData.horizontalSpan = 3;
 		appVersion.setLayoutData(versionData);
 		appVersion.setEditable(false);
+	}
+	
+	protected Model readModel(File pomXmlFile) {
+		Model model = null;
+		try (Reader reader = new FileReader(pomXmlFile)) {
+			MavenXpp3Reader xpp3Reader = new MavenXpp3Reader();
+			if (pomXmlFile.length() != 0)
+				model = xpp3Reader.read(reader);
+			else
+				model = new Model();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return model;
 	}
 
 	private void createModulesTable() {

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
@@ -62,7 +62,7 @@ public class WizardPageConfiguration extends WizardPage {
 	public WizardPageConfiguration(String pageName, BWProject project) {
 		super(pageName);
 		this.project = project;
-		setTitle("Maven Configuration Details for Plugin Code for Apache Maven and TIBCO BusinessWorks");
+		setTitle("Maven Configuration Details for Plugin Code for Apache Maven and TIBCO BusinessWorks(TM)");
 		if(project.getType() == BWProjectType.Application){
 			setDescription("Enter the GroupId and ArtifactId for Maven POM File generation.\nPOM files will be generated for Projects listed below and Parent POM file will be generated aggregating the Projects");
 


### PR DESCRIPTION
****What's this Pull request about?
The pull request about the solution for the issue #186 pom.xml file is empty in project module
and issue #2 BW6 Maven plugin Generate POM dialog text is not visible.

****Which Issue(s) this Pull Request will fix?
The pull request will fix issue #186 pom.xml file is empty in the project module.
and issue#2 BW6 Maven plugin Generate POM dialog text is not visible.

****Does this pull request maintain backward compatibility?
yes

****How this pull request has been tested?
1) Create new application module with target platform container. Generate Pom with deployment
option None.
2) Create a new Shared Module. Generate Pom.

****Screenshots (if appropriate)
<img width="897" alt="test" src="https://user-images.githubusercontent.com/40194420/46143023-64ed4180-c276-11e8-89e2-6fcdf39f8d1a.png">

****Any background context or comments you want to provide?
I have created one new method setBwEdition in AbstractPOMBuilder.java file which returns BwEdition
value and modified method readModel in AbstractPOMBuilder.java file.
Also, I have added TM in WizardPageConfiguration.java file.