### PR TITLE
Issue #134: Error creating pom.xml file in OS Windows, the character "\" is wrong.  Issue #58 : Cannot find environment property file 'docker-host-env-dev.properties' .  Issue #200 :  PCF - URL for app contains wrong domain

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/FileHelper.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/helpers/FileHelper.java
@@ -9,6 +9,10 @@ public class FileHelper {
         Path pathAbsolute = Paths.get(path1);
         Path pathBase = Paths.get(path2);
         Path pathRelative = pathBase.relativize(pathAbsolute);
-        return pathRelative.toString();
+        String relativePath= pathRelative.toString();
+        if(relativePath!=null){
+        	relativePath = relativePath.replace("\\", "/");
+        }
+        return relativePath; 
 	}
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWPCFModule.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/modules/model/BWPCFModule.java
@@ -17,6 +17,8 @@ public class BWPCFModule {
 	
 	private String appName;
 	
+	private String pcfDomain;
+	
 	private String instances;
 	
 	private String memory;
@@ -115,6 +117,15 @@ public class BWPCFModule {
 
 	public void setCfEnvVariables(Map<String, String> cfEnvVariables) {
 		this.cfEnvVariables = cfEnvVariables;
+	}
+	
+	public String getPCFDomain() {
+		return pcfDomain;
+	}
+
+	public void setPCFDomain(String pcfDomain) {
+		this.pcfDomain = pcfDomain;
+		
 	}
 
 	

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -63,8 +63,12 @@ public abstract class AbstractPOMBuilder {
 			properties = new Properties();
 		}
 		properties.put("docker.property.file", "docker-dev.properties");
-		if(module.getBwDockerModule().getDockerEnvs() != null && module.getBwDockerModule().getDockerEnvs().size() > 0) {
-			properties.put("docker.env.property.file", "docker-host-env-dev.properties");
+		String workspacePath = getWorkspacepath();
+		if(module.getBwDockerModule().getDockerEnvs() != null && module.getBwDockerModule().getDockerEnvs().size() > 0 && workspacePath!=null) {
+			String envPropFile = workspacePath+File.separator+"docker-host-env-dev.properties";
+			if(workspacePath.endsWith(File.separator))
+				envPropFile = workspacePath+"docker-host-env-dev.properties";
+			properties.put("docker.env.property.file", envPropFile);
 		} else {
 			if(properties.containsKey("docker.env.property.file")) {
 				properties.remove("docker.env.property.file");
@@ -79,6 +83,7 @@ public abstract class AbstractPOMBuilder {
 		}
 		model.setProperties(properties);
 	}
+
 
 	protected void addPrimaryTags() {
 		model.setModelVersion("4.0.0");

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -260,12 +260,12 @@ public abstract class AbstractPOMBuilder {
 		plugin.setGroupId("io.fabric8");
 		plugin.setArtifactId("fabric8-maven-plugin");
 		plugin.setVersion("3.5.41");
-		
+
 		Xpp3Dom config = new Xpp3Dom("configuration");
 		Xpp3Dom child = new Xpp3Dom("skip");
 		child.setValue(String.valueOf(skip));
 		config.addChild(child);
-	
+
 		plugin.setConfiguration(config);
 		build.addPlugin(plugin);
 	}
@@ -439,7 +439,7 @@ public abstract class AbstractPOMBuilder {
 			e.printStackTrace();
 		}
 	}
-	
+
 	private void createK8SPropertiesFiles() {
 		try {
 			Properties properties = new Properties();
@@ -458,7 +458,7 @@ public abstract class AbstractPOMBuilder {
 				properties.setProperty("fabric8.service.type", "LoadBalancer");
 			}
 			else{
-			properties.setProperty("fabric8.service.type", module.getBwk8sModule().getServiceType());
+				properties.setProperty("fabric8.service.type", module.getBwk8sModule().getServiceType());
 			}
 			properties.setProperty("fabric8.service.port", "80");
 			properties.setProperty("fabric8.provider", "Tibco");
@@ -466,7 +466,7 @@ public abstract class AbstractPOMBuilder {
 			properties.setProperty("fabric8.namespace", module.getBwk8sModule().getK8sNamespace());
 			properties.setProperty("fabric8.apply.namespace", module.getBwk8sModule().getK8sNamespace());
 			if(module.getBwk8sModule().getResourcesLocation()!=null){
-			properties.setProperty("fabric8.resources.location", module.getBwk8sModule().getResourcesLocation());
+				properties.setProperty("fabric8.resources.location", module.getBwk8sModule().getResourcesLocation());
 			}
 
 			//Add k8s env variables
@@ -566,7 +566,7 @@ public abstract class AbstractPOMBuilder {
 			properties.setProperty("bwpcf.trustSelfSignedCerts", "true");
 			properties.setProperty("bwpcf.org", module.getBwpcfModule().getOrg());
 			properties.setProperty("bwpcf.appName", module.getBwpcfModule().getAppName());
-			
+
 			properties.setProperty("bwpcf.space", module.getBwpcfModule().getSpace());
 			if(module.getBwpcfModule().getPCFDomain() != null && !module.getBwpcfModule().getPCFDomain().isEmpty()) {
 				properties.setProperty("bwpcf.url", getPCFAppURLForDomain(module.getBwpcfModule().getAppName(), module.getBwpcfModule().getPCFDomain()));
@@ -660,7 +660,7 @@ public abstract class AbstractPOMBuilder {
 		child = new Xpp3Dom("appname");
 		child.setValue("${bwpcf.appName}");
 		config.addChild(child);
-		
+
 
 		child = new Xpp3Dom("url");
 		child.setValue("${bwpcf.url}");
@@ -724,14 +724,14 @@ public abstract class AbstractPOMBuilder {
 		plugin.setConfiguration(config);	
 		build.addPlugin(plugin);
 	}
-	
-private String getPCFAppURLForDomain(String appName, String domain) {
+
+	private String getPCFAppURLForDomain(String appName, String domain) {
 		appName = appName.replace(".", "-");
 		return appName + "." + domain;
 	}
 
 	private String getPCFAppURL(String appName) {
-		
+
 		appName = appName.replace(".", "-");
 		String domainStr = module.getBwpcfModule().getTarget();
 		String protoDom = domainStr.substring(0, domainStr.indexOf("."));

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -726,7 +726,7 @@ public abstract class AbstractPOMBuilder {
 	}
 	
 private String getPCFAppURLForDomain(String appName, String domain) {
-		
+		appName = appName.replace(".", "-");
 		return appName + "." + domain;
 	}
 

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -84,7 +84,6 @@ public abstract class AbstractPOMBuilder {
 		model.setProperties(properties);
 	}
 
-
 	protected void addPrimaryTags() {
 		model.setModelVersion("4.0.0");
 		model.setArtifactId( module.getArtifactId());
@@ -567,9 +566,12 @@ public abstract class AbstractPOMBuilder {
 			properties.setProperty("bwpcf.trustSelfSignedCerts", "true");
 			properties.setProperty("bwpcf.org", module.getBwpcfModule().getOrg());
 			properties.setProperty("bwpcf.appName", module.getBwpcfModule().getAppName());
+			
 			properties.setProperty("bwpcf.space", module.getBwpcfModule().getSpace());
-
-			if(module.getBwpcfModule().getAppName() != null && !module.getBwpcfModule().getAppName().isEmpty()) {
+			if(module.getBwpcfModule().getPCFDomain() != null && !module.getBwpcfModule().getPCFDomain().isEmpty()) {
+				properties.setProperty("bwpcf.url", getPCFAppURLForDomain(module.getBwpcfModule().getAppName(), module.getBwpcfModule().getPCFDomain()));
+			}
+			else if(module.getBwpcfModule().getAppName() != null && !module.getBwpcfModule().getAppName().isEmpty()) {
 				properties.setProperty("bwpcf.url", getPCFAppURL(module.getBwpcfModule().getAppName()));
 			} else {
 				properties.setProperty("bwpcf.url", getPCFAppDefaultURL());
@@ -658,6 +660,7 @@ public abstract class AbstractPOMBuilder {
 		child = new Xpp3Dom("appname");
 		child.setValue("${bwpcf.appName}");
 		config.addChild(child);
+		
 
 		child = new Xpp3Dom("url");
 		child.setValue("${bwpcf.url}");
@@ -721,8 +724,14 @@ public abstract class AbstractPOMBuilder {
 		plugin.setConfiguration(config);	
 		build.addPlugin(plugin);
 	}
+	
+private String getPCFAppURLForDomain(String appName, String domain) {
+		
+		return appName + "." + domain;
+	}
 
 	private String getPCFAppURL(String appName) {
+		
 		appName = appName.replace(".", "-");
 		String domainStr = module.getBwpcfModule().getTarget();
 		String protoDom = domainStr.substring(0, domainStr.indexOf("."));

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ParentPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/ParentPOMBuilder.java
@@ -115,9 +115,10 @@ public class ParentPOMBuilder extends AbstractPOMBuilder implements IPOMBuilder 
 	}
 
 	protected void addModules() {
-		if (model.getModules().size() > 0) {
-			return;
-		}
+		while(model.getModules().size()>0){
+			String module= model.getModules().get(0);
+			model.removeModule(module);
+		}			
 		for (BWModule module : project.getModules()) {
 			if (module.getType() == BWModuleType.PluginProject) {
 				model.getModules().add(module.getToPath());

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPagePCF.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPagePCF.java
@@ -103,7 +103,7 @@ public class WizardPagePCF extends WizardPage {
 		pcfDomainLabel.setText("PCF Domain");
 		
 		appPCFDomain = new Text(container, SWT.BORDER | SWT.SINGLE);
-		appPCFDomain.setText("AppDomain");
+		
 		GridData appDomainData = new GridData(100, 15);
 		appPCFAppName.setLayoutData(appDomainData);
 		

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPagePCF.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPagePCF.java
@@ -33,6 +33,7 @@ public class WizardPagePCF extends WizardPage {
 	private Text appPCFOrg;
 	private Text appPCFSpace;
 	private Text appPCFAppName;
+	private Text appPCFDomain;
 	private Text appPCFInstances;
 	private Text appPCFMemory;
 	private Text appPCFBuildpack;
@@ -97,6 +98,15 @@ public class WizardPagePCF extends WizardPage {
 		GridData appNameData = new GridData(100, 15);
 		appPCFAppName.setLayoutData(appNameData);
 
+		
+		Label pcfDomainLabel = new Label(container, SWT.RIGHT);
+		pcfDomainLabel.setText("PCF Domain");
+		
+		appPCFDomain = new Text(container, SWT.BORDER | SWT.SINGLE);
+		appPCFDomain.setText("AppDomain");
+		GridData appDomainData = new GridData(100, 15);
+		appPCFAppName.setLayoutData(appDomainData);
+		
 		Label instancesLabel = new Label(container, SWT.RIGHT);
 		instancesLabel.setText("App Instances");
 
@@ -173,6 +183,7 @@ public class WizardPagePCF extends WizardPage {
 		bwpcf.setOrg(appPCFOrg.getText());
 		bwpcf.setSpace(appPCFSpace.getText());
 		bwpcf.setAppName(appPCFAppName.getText());
+		bwpcf.setPCFDomain(appPCFDomain.getText());
 		bwpcf.setInstances(appPCFInstances.getText());
 		bwpcf.setMemory(appPCFMemory.getText());
 		bwpcf.setBuildpack(appPCFBuildpack.getText());


### PR DESCRIPTION
****What's this Pull request about?

1. Changing the relative location path separator to '/'  for modules listed in the parent POM file. Changing the parent project's relative path to contain '/' in place of '\' in the module and application POM files. Also regenerating  a POM file by updating the module paths when user clicks on 'Generate POM for application'.  

2. Updating the location of the docker environment properties file to point to the correct absolute location.

3. Adding a new UI field for the PCF domain to be configurable by users for BWCE apps, while generating the POM file.

****Which Issue(s) this Pull Request will fix?

This pull Request fixes issue #134 , in which the character '/' is required to be used in place of '\' while specifying the module paths in the POM files.

#58 is also fixed by this. The location of the docker environment property file has been specified as absolute path, to resolve file not found error.

It also fixes #200 , by adding the PCF domain in which the app is to be deployed as a UI field, so that it can be configured by users wishing to deploy PCF apps in different domains.


****Does this pull request maintain backward compatibility?
Backward compatibility with existing projects is maintained. Existing projects will run without changes. At design time, if user clicks on 'Generate POM for application' for an already existing maven project, the module paths in the parent POM file will be replaced with the updated module paths.

****How this pull request has been tested?

Tested following scenarios:

For issue #134 : 
1. Created a new BW maven project, and verified the generated POMs. Verified the contents of the JAR and EAR files after maven build.
2. Tested by regenerating POMs for already existing projects. The module paths are updated with '/' in place of '\'. The '/' character is recognized by Windows as well as Linux.

For issue #58 : 
1. Tested that the docker-env-dev.properties file path is read correctly and the docker environment properties are accessible to the application.

For issue #200 : 
1. Tested that the PCF URL in the PCF properties file is generated according to the domain specified in the UI field in the PCF wizard page, while generating the POM. The user need not reconfigure the URL values in the properties files to change the domain, and can simply regenerate the POM file with the required domain value.
2. Only in cases where the domain value is not specified, the PCF URL will be derived from the PCF target.

Screenshot of the new field added in the PCF wizard page :
![pcfdomain](https://user-images.githubusercontent.com/21974930/46934806-c2ef9680-d076-11e8-9bb8-fe06aaacb435.png)

