### PR TITLE
AMBW-33534 : Studio freeze if we try to create Rest Service in project having a shared Module imported using Maven POM file

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
@@ -23,6 +23,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectNature;
+import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -290,14 +291,18 @@ public class BWMavenDependenciesBuilder extends BWAbstractBuilder{
 		TransactionalEditingDomain editingDomain = EditingDomainUtil.INSTANCE.getEditingDomain(); 
 		if(editingDomain != null){
 			
-			RecordingCommand command = new RecordingCommand(editingDomain) {
-				@Override
-				protected void doExecute() {
-					ModelHelper.INSTANCE.addModulesToApplication(projects, sourceProject);
-				}
-			};
+			WorkspaceJob job = new WorkspaceJob(editingDomain.getID()) {
 
-			editingDomain.getCommandStack().execute(command);
+				@Override
+				public IStatus runInWorkspace(IProgressMonitor monitor)
+						throws CoreException {
+					ModelHelper.INSTANCE.addModulesToApplication(projects, sourceProject);
+					return Status.OK_STATUS;
+				}
+				
+			};
+			
+		job.schedule();
 		}
 	}
 

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
@@ -23,7 +23,6 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectNature;
-import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -288,22 +287,9 @@ public class BWMavenDependenciesBuilder extends BWAbstractBuilder{
 			projects.add(handler.getProject());
 		}
 		
-		TransactionalEditingDomain editingDomain = EditingDomainUtil.INSTANCE.getEditingDomain(); 
-		if(editingDomain != null){
-			
-			WorkspaceJob job = new WorkspaceJob(editingDomain.getID()) {
-
-				@Override
-				public IStatus runInWorkspace(IProgressMonitor monitor)
-						throws CoreException {
-					ModelHelper.INSTANCE.addModulesToApplication(projects, sourceProject);
-					return Status.OK_STATUS;
-				}
-				
-			};
-			
-		job.schedule();
-		}
+	
+		ModelHelper.INSTANCE.addModulesToApplication(projects, sourceProject);
+		
 	}
 
 	protected void registerDependencies(List<BWExternalDependencyRecord>records, IProject hostProject){


### PR DESCRIPTION

****Which Issue(s) this Pull Request will fix?

The pull request fixes AMBW-33534 : BW Studio hangs on importing shared module as maven dependency. The studio no longer freezes on importing the dependency, and trying to create a new resource. The validation process now runs as a WorkspaceJob , and not as a UI thread which locks the EMF resource. 

****Does this pull request maintain backward compatibility?
Yes, since only the UI thread for adding maven dependencies to the application, has been replaced by a WorkspaceJob. 

****How this pull request has been tested?
Tested out the maven package goal to ensure that the generated archives contain the shared module in the required libraries, and as POM entry, after the code changes were applied.

