### PR TITLE
Fix for issue #218 Title for generating pom wizard is missing

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -876,6 +876,9 @@ public abstract class AbstractPOMBuilder {
 				}
 
 			}
+		}else {
+			// "TIBCO-BW-Edition" value in manifest is not set, default value of bwEdition will be "bw6".
+			bwEdition="bw6";
 		}
 		return bwEdition;
 	}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
@@ -58,6 +58,9 @@ public class MavenWizard extends Wizard {
 						}
 					}
 				}
+			}else {
+				// "TIBCO-BW-Edition" value in manifest is not set, default will be "bwe".
+				MavenWizardContext.INSTANCE.getProjectTypes().add( BWProjectTypes.AppSpace );
 			}
 
 			MavenWizardContext.INSTANCE.setConfigPage(new WizardPageConfiguration("POM Configuration", project));

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
@@ -12,7 +12,8 @@ import com.tibco.bw.studio.maven.modules.model.BWProjectType;
 
 public class MavenWizard extends Wizard {
 	private BWProject project;
-
+	private String windowTitle ="Generate POM for Application";
+	
 	public MavenWizard(BWProject project) {
 		super();
 		this.project = project;
@@ -122,4 +123,14 @@ public class MavenWizard extends Wizard {
 	public BWProject getProject() {
 		return project;
 	}
+	
+	@Override
+	public String getWindowTitle() {
+        return windowTitle;
+    }
+	
+	@Override
+	 public void setWindowTitle(String newTitle) {
+	        windowTitle = newTitle;
+    }
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
@@ -189,13 +189,13 @@ public class WizardPageConfiguration extends WizardPage {
 
 	private void addNotes() {
 		Label label = new Label(container, SWT.NONE);
-		label.setText("Note* : The Maven ArtifactId and the Bundle-SymbolicName should be same.");
+		label.setText("Note* : Maven ArtifactId and Bundle-SymbolicName should be same.");
 		GridData versionData = new GridData();
 		versionData.horizontalSpan = 4;
 		label.setLayoutData(versionData);
 
 		Label label1 = new Label(container, SWT.NONE);
-		label1.setText("Note* : The Maven Version and the Bundle-Version should be same.");
+		label1.setText("Note* : Maven Version the Bundle-Version should be same.");
 		versionData = new GridData();
 		versionData.horizontalSpan = 4;
 		label1.setLayoutData(versionData);


### PR DESCRIPTION
****What's this Pull request about?

Fix for the issue #218 Title for" generating pom for application" wizard is missing for maven plugin. 

****Which Issue(s) this Pull Request will fix?

Issue #218 

****Does this pull request maintain backward compatibility?
Yes

****How this pull request has been tested?
1) Create One Businesswork Application Module
2) Click on Generate Pom for Application
3) Check Pom Generation Wizard title.

****Screenshots (if appropriate)

Screenshot(s) of the change

<img width="958" alt="pomwizard" src="https://user-images.githubusercontent.com/40194420/49858654-8bedf500-fe1b-11e8-831d-8498d94998a6.png">

****Any background context or comments you want to provide?

Modification of code done in WizardPageConfiguration.java and MavenWizard.java.




