### PR TITLE
Fix for Issue #234

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
@@ -187,6 +187,9 @@ public class BWMavenDependenciesBuilder extends BWAbstractBuilder{
 			String artifactId = dependency.getArtifactId();
 			String version = dependency.getVersion();
 			String type = dependency.getType();
+			if("bwmodule".equalsIgnoreCase(type)){
+				type = "jar";
+			}
 			String classifier = dependency.getClassifier();
 
 			Artifact artifact = maven.resolve(groupId, artifactId, version, type, classifier, maven.getArtifactRepositories(), null);


### PR DESCRIPTION
****What's this Pull request about?
External Shared Module not imported in Studio after searching the available ESM using Group ID in Dependency section of the POM.xml

****Which Issue(s) this Pull Request will fix?

Fix for Issue #234

****Does this pull request maintain backward compatibility?
Yes

****How this pull request has been tested?

Add shared module dependency using Group ID search in Dependency section of the POM.xml

****Any background context or comments you want to provide?
When we add shared module using group id search from dependency section of POM it is added as 'bwmodule' type but when we add shared module by providing groupid, artifact id, version it is added as 'jar' type. The code was written in a way that when shared module type is jar , only then it would be  imported in workspace.

Short description of why these changes were made.

Now we can add ESM dependency from repository by searching the available ESM using Group ID .



