### PR TITLE
"Fix for issue #218 Title for generating pom wizard is missing"

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
@@ -12,6 +12,7 @@ import com.tibco.bw.studio.maven.modules.model.BWProjectType;
 
 public class MavenWizard extends Wizard {
 	private BWProject project;
+	private String windowTitle ="Generate POM for Application";
 
 	public MavenWizard(BWProject project) {
 		super();
@@ -122,4 +123,9 @@ public class MavenWizard extends Wizard {
 	public BWProject getProject() {
 		return project;
 	}
+	
+	@Override
+	public String getWindowTitle() {
+        return windowTitle;
+    }
 }

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/WizardPageConfiguration.java
@@ -189,13 +189,13 @@ public class WizardPageConfiguration extends WizardPage {
 
 	private void addNotes() {
 		Label label = new Label(container, SWT.NONE);
-		label.setText("Note* : The Maven ArtifactId and the Bundle-SymbolicName should be same.");
+		label.setText("Note* : Maven ArtifactId and Bundle-SymbolicName should be same.");
 		GridData versionData = new GridData();
 		versionData.horizontalSpan = 4;
 		label.setLayoutData(versionData);
 
 		Label label1 = new Label(container, SWT.NONE);
-		label1.setText("Note* : The Maven Version and the Bundle-Version should be same.");
+		label1.setText("Note* : Maven Version and Bundle-Version should be same.");
 		versionData = new GridData();
 		versionData.horizontalSpan = 4;
 		label1.setLayoutData(versionData);


### PR DESCRIPTION
****What's this Pull request about?

Fix for the issue #218 Title for" generating pom for application" wizard is missing for maven plugin.

****Which Issue(s) this Pull Request will fix?

Issue #218

****Does this pull request maintain backward compatibility?
Yes

****How this pull request has been tested?

Create One Businesswork Application Module
Click on Generate Pom for Application
Check Pom Generation Wizard title.
****Screenshots (if appropriate)

Screenshot(s) of the change

<img width="593" alt="pom" src="https://user-images.githubusercontent.com/40194420/51456608-5b7f6c00-1d74-11e9-9bf3-3065c8ea0cea.PNG">


****Any background context or comments you want to provide?

Modification of code done in WizardPageConfiguration.java and MavenWizard.java.