### PR TITLE
"fix for the issue 3232 and issue #217"

### DIFF
--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/pom/builders/AbstractPOMBuilder.java
@@ -876,6 +876,9 @@ public abstract class AbstractPOMBuilder {
 				}
 
 			}
+		} else {
+			// "TIBCO-BW-Edition" value in manifest is not set, default value of bwEdition will be "bw6".
+			bwEdition = "bw6";
 		}
 		return bwEdition;
 	}

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/wizard/MavenWizard.java
@@ -58,6 +58,9 @@ public class MavenWizard extends Wizard {
 						}
 					}
 				}
+			}else{
+				// "TIBCO-BW-Edition" value in manifest is not set, default will be "bwe".
+				MavenWizardContext.INSTANCE.getProjectTypes().add( BWProjectTypes.AppSpace );
 			}
 
 			MavenWizardContext.INSTANCE.setConfigPage(new WizardPageConfiguration("POM Configuration", project));


### PR DESCRIPTION
****What's this Pull request about?
The fix for the issue #232 POM Generated shows error as 'Project Build Error: Non-Readable Pom' in App Module.
and the issue #217 Deployment Option for App Space edition projects appear as 'NONE' while generating pom.xml using maven plugin

****Which Issue(s) this Pull Request will fix?
This pull request will fix the issue #232 and issue #217.

****Does this pull request maintain backward compatibility?
yes

****How this pull request has been tested?

1)**For issue #217 (Deployment option appear as "NONE".)**
         1) Import Existing older project in 651 workspaces. For the older project, the manifest file doesn't
             contain TIBCO-BW-Edition watermark.
         2) Right click on the .application and Select Generate POM for application
         3) Select deployment option and observe option as "NONE" and "Appsapce".

![noneopt](https://user-images.githubusercontent.com/40194420/51589525-4ee24b80-1f0d-11e9-9f48-3c9e0f68da2c.png)

2)**For the issue #232 (non readble POM)**
        1) Import Existing older project in 651 workspaces. For the older project, the manifest file doesn't
           contain TIBCO-BW-Edition watermark.
        2) Right click on the .application and Select Generate POM for application
        3) Check the pom.xml file in the App Module. pom file has no error.

<img width="954" alt="pomreadble" src="https://user-images.githubusercontent.com/40194420/51589625-9072f680-1f0d-11e9-9b3d-b508b2eaff37.PNG">

****Any background context or comments you want to provide?
When the manifest file doesn't contain **TIBCO-BW-Edition** watermark, the default will be set as **bwe**.