### PR TITLE
Externalise path of Eclipse Equinox Launcher jar

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
@@ -28,44 +28,44 @@ public class BWTestMojo extends AbstractMojo {
 
     @Parameter( property = "testFailureIgnore", defaultValue = "false" )
     private boolean testFailureIgnore;
-    
+
     @Parameter( property = "skipTests", defaultValue = "false" )
     protected boolean skipTests;
 
     @Parameter( property = "failIfNoTests" , defaultValue = "true" )
     private boolean failIfNoTests;
-    
+
     @Parameter( property = "disableMocking" , defaultValue = "false" )
     private boolean disableMocking;
-    
+
     @Parameter( property = "disableAssertions" , defaultValue = "false" )
     private boolean disableAssertions;
-    
+
     @Parameter( property = "engineDebugPort" , defaultValue = "8090" )
     private int engineDebugPort;
-    
-    
-    
-    
+
+
+
+
     public void execute() throws MojoExecutionException , MojoFailureException
     {
-    	
+
     	BWTestExecutor executor = new BWTestExecutor();
-    	try 
+    	try
     	{
-    	
+
     		session.getProjects();
-    		
+
     		if( !verifyParameters() )
     		{
     			return;
     		}
-    		   		
+
     		initialize();
-    		
+
 			executor.execute();
 		}
-    	catch (Exception e) 
+    	catch (Exception e)
     	{
 
     		if( e instanceof MojoFailureException )
@@ -82,30 +82,30 @@ public class BWTestMojo extends AbstractMojo {
     		}
     		else
     		{
-    			
+
     			e.printStackTrace();
     			throw new MojoExecutionException( e.getMessage(), e);
     		}
 		}
-    	
+
     }
 
-    
-    
+
+
     private boolean verifyParameters() throws Exception
     {
-    	
-    	
+
+
     	if( isSkipTests() )
     	{
 			getLog().info( "-------------------------------------------------------" );
     		getLog().info( "Skipping Test phase.");
 			getLog().info( "-------------------------------------------------------" );
 
-    		
+
     		return false;
     	}
-    	
+
     	String tibcoHome = project.getProperties().getProperty("tibco.Home");
 		String bwHome = project.getProperties().getProperty("bw.Home");
 
@@ -117,19 +117,28 @@ public class BWTestMojo extends AbstractMojo {
 
 			return false;
 		}
-		
+
 		File file = new File( tibcoHome + bwHome );
 		if( !file.exists() || !file.isDirectory()  )
 		{
 			getLog().info( "-------------------------------------------------------" );
 			getLog().info( "Provided TibcoHome directory is invalid. Skipping Test Phase.");
 			getLog().info( "-------------------------------------------------------" );
-	
+
 			return false;
 		}
+        File eclipseDependenciesDir = new File( tibcoHome + "/tools/p2director/eclipse/plugins");
+        if( !eclipseDependenciesDir.exists())
+		{
+            getLog().info("-------------------------------------------------------");
+            getLog().info("No Eclipse Dependencies found. Skipping Test Phase.");
+            getLog().info("-------------------------------------------------------");
+
+            return false;
+        }
 		boolean exists = checkForTest();
-		
-    	
+
+
     	if( getFailIfNoTests() )
     	{
     		if(!exists )
@@ -147,14 +156,14 @@ public class BWTestMojo extends AbstractMojo {
     			return false;
     		}
     	}
-    		
-    	
-    	
+
+
+
     	return true;
-    	
+
     }
-    
-    
+
+
     private boolean checkForTest()
     {
     	List<MavenProject> projects = session.getProjects();
@@ -172,32 +181,32 @@ public class BWTestMojo extends AbstractMojo {
 		getLog().info( "-------------------------------------------------------" );
 		getLog().info( "No BWT Test files exist. ");
 		getLog().info( "-------------------------------------------------------" );
-    	
+
     	return false;
     }
-    
+
     private void initialize() throws Exception
     {
 		String tibcoHome = project.getProperties().getProperty("tibco.Home");
 		String bwHome = project.getProperties().getProperty("bw.Home");
-		
+
 		TestFileParser.INSTANCE.setdisbleMocking(disableMocking);
-		
+
 		TestFileParser.INSTANCE.setdisbleAssertions(disableAssertions);
-		
+
 		BWTestExecutor.INSTANCE.setEngineDebugPort(engineDebugPort);
 
     	BWTestConfig.INSTANCE.reset();
-		
+
 		BWTestConfig.INSTANCE.init(  tibcoHome , bwHome , session, project , getLog() );
-		
+
 		getLog().info( "" );
 		getLog().info( "-------------------------------------------------------" );
 		getLog().info( " Running BW Tests " );
 		getLog().info( "-------------------------------------------------------" );
     }
-    
-    
+
+
 	public boolean isSkipTests()
 	{
 		if( ! skipTests )
@@ -221,19 +230,19 @@ public class BWTestMojo extends AbstractMojo {
 
 
 
-	public boolean isTestFailureIgnore() 
+	public boolean isTestFailureIgnore()
 	{
 		return testFailureIgnore;
 	}
 
-	public void setTestFailureIgnore(boolean testFailureIgnore) 
+	public void setTestFailureIgnore(boolean testFailureIgnore)
 	{
 		this.testFailureIgnore = testFailureIgnore;
 	}
 
 
 
-	public boolean getFailIfNoTests() 
+	public boolean getFailIfNoTests()
 	{
 		return failIfNoTests;
 	}

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/BWTestConfig.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/BWTestConfig.java
@@ -8,138 +8,128 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
-public class BWTestConfig 
-{
+public class BWTestConfig {
 
-	public static BWTestConfig INSTANCE = new BWTestConfig();
+    public static BWTestConfig INSTANCE = new BWTestConfig();
 
-	private File configDir;
+    private File configDir;
 
-	private Process engineProcess;
-	
-	private List<String> launchConfig;
+    private Process engineProcess;
 
-	private String tibcoHome;
-	
-	private String bwHome;
-	
-	private MavenSession session;
-	
-	private MavenProject project;
-	
-	private Log logger;
-	
-	private BWTestConfig()
-	{
-		
-	}
-	
-	public  void reset()
-	{
-		INSTANCE = new BWTestConfig();
-	}
-	
-	public void init( String tibcoHome , String bwHome , MavenSession session , MavenProject project , Log logger ) throws Exception 
-	{
-		this.tibcoHome = tibcoHome;
-		this.session = session;
-		this.project = project;
-		this.bwHome = bwHome;
-		this.logger = logger;
-		
-		initConfig();
-	}
-	
-	private void initConfig() throws Exception
-	{
-		String temp = System.getProperty( "java.io.tmpdir" );
-		File file = new File( temp );
-		
-		configDir = new File( file , "bwconfig");
-		
-		configDir.mkdir();
-		
-		FileUtils.cleanDirectory(configDir );
-	}
+    private List<String> launchConfig;
 
-	public File getConfigDir() 
-	{
-		return configDir;
-	}
+    private String tibcoHome;
 
-	public void setConfigDir(File configDir) 
-	{
-		this.configDir = configDir;
-	}
+    private String bwHome;
 
-	public Process getEngineProcess() 
-	{
-		return engineProcess;
-	}
+    private String eclipsePluginsPath;
 
-	public void setEngineProcess(Process engineProcess)
-	{
-		this.engineProcess = engineProcess;
-	}
+    private MavenSession session;
 
-	public List<String> getLaunchConfig() 
-	{
-		return launchConfig;
-	}
+    private MavenProject project;
 
-	public void setLaunchConfig(List<String> launchConfig)
-	{
-		this.launchConfig = launchConfig;
-	}
+    private Log logger;
 
-	public String getTibcoHome() 
-	{
-		return tibcoHome;
-	}
+    private BWTestConfig() {
 
-	public void setTibcoHome(String tibcoHome) 
-	{
-		this.tibcoHome = tibcoHome;
-	}
+    }
 
-	public String getBwHome() 
-	{
-		return bwHome;
-	}
+    public void reset() {
+        INSTANCE = new BWTestConfig();
+    }
 
-	public void setBwHome(String bwHome)
-	{
-		this.bwHome = bwHome;
-	}
+    public void init(String tibcoHome, String bwHome, String eclipsePluginsPath, MavenSession session, MavenProject project, Log logger) throws Exception {
+        this.tibcoHome = tibcoHome;
+        this.session = session;
+        this.project = project;
+        this.bwHome = bwHome;
+        this.logger = logger;
+        this.eclipsePluginsPath = eclipsePluginsPath;
 
-	public MavenSession getSession()
-	{
-		return session;
-	}
+        initConfig();
+    }
 
-	public void setSession(MavenSession session) 
-	{
-		this.session = session;
-	}
+    private void initConfig() throws Exception {
+        String temp = System.getProperty("java.io.tmpdir");
+        File file = new File(temp);
 
-	public MavenProject getProject() 
-	{
-		return project;
-	}
+        configDir = new File(file, "bwconfig");
 
-	public void setProject(MavenProject project) 
-	{
-		this.project = project;
-	}
+        configDir.mkdir();
 
-	public Log getLogger() 
-	{
-		return logger;
-	}
+        FileUtils.cleanDirectory(configDir);
+    }
 
-	public void setLogger(Log logger) 
-	{
-		this.logger = logger;
-	}
-	
+    public File getConfigDir() {
+        return configDir;
+    }
+
+    public void setConfigDir(File configDir) {
+        this.configDir = configDir;
+    }
+
+    public Process getEngineProcess() {
+        return engineProcess;
+    }
+
+    public void setEngineProcess(Process engineProcess) {
+        this.engineProcess = engineProcess;
+    }
+
+    public List<String> getLaunchConfig() {
+        return launchConfig;
+    }
+
+    public void setLaunchConfig(List<String> launchConfig) {
+        this.launchConfig = launchConfig;
+    }
+
+    public String getTibcoHome() {
+        return tibcoHome;
+    }
+
+    public void setTibcoHome(String tibcoHome) {
+        this.tibcoHome = tibcoHome;
+    }
+
+    public String getBwHome() {
+        return bwHome;
+    }
+
+    public void setBwHome(String bwHome) {
+        this.bwHome = bwHome;
+    }
+
+    public MavenSession getSession() {
+        return session;
+    }
+
+    public void setSession(MavenSession session) {
+        this.session = session;
+    }
+
+    public MavenProject getProject() {
+        return project;
+    }
+
+    public void setProject(MavenProject project) {
+        this.project = project;
+    }
+
+    public Log getLogger() {
+        return logger;
+    }
+
+    public void setLogger(Log logger) {
+        this.logger = logger;
+    }
+
+    public String getEclipsePluginsPath() {
+        return eclipsePluginsPath;
+    }
+
+    public BWTestConfig setEclipsePluginsPath(String eclipsePluginsPath) {
+        this.eclipsePluginsPath = eclipsePluginsPath;
+        return this;
+    }
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestsReport.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestsReport.java
@@ -102,10 +102,11 @@ public class BWTestsReport extends AbstractMavenReport
 		
 		String tibcoHome = "";
 		String bwHome = "";
+		String eclipsePluginsPath ="";
 		Log logger =  getLog();
 		
 		try {
-			BWTestConfig.INSTANCE.init(  tibcoHome , bwHome , session, getProject() , logger );
+			BWTestConfig.INSTANCE.init(  tibcoHome , bwHome ,eclipsePluginsPath, session, getProject() , logger );
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineLaunchConfigurator.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineLaunchConfigurator.java
@@ -102,6 +102,10 @@ public class EngineLaunchConfigurator
 				{
 					currentLine = currentLine.replace("%%ENGINE_DEBUG_PORT%%", String.valueOf(BWTestExecutor.INSTANCE.getEngineDebugPort()) );
 				}
+				if( currentLine.contains("%%ECLIPSE_PLUGINS%%"))
+				{
+					currentLine = currentLine.replace("%%ECLIPSE_PLUGINS%%", BWTestConfig.INSTANCE.getEclipsePluginsPath());
+				}
 				if( currentLine.equals("-dev"))
 				{
 					if( isDev)

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/environment.properties
@@ -21,7 +21,7 @@
 -DBW_HOME=%%TIBCO_HOME%%/bw/6.5
 -Dbw.governance.enabled=false
 -classpath
-%%TIBCO_HOME%%/tools/p2director/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
+%%ECLIPSE_PLUGINS%%/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
 org.eclipse.equinox.launcher.Main
 -configuration
 file:%%CONFIG_DIR%%

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
@@ -23,7 +23,7 @@
 -DBW_HOME=%%TIBCO_HOME%%/%%BW_HOME%%
 -Dbw.governance.enabled=false
 -classpath
-%%TIBCO_HOME%%/tools/p2director/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
+%%ECLIPSE_PLUGINS%%/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
 org.eclipse.equinox.launcher.Main
 -dev
 -configuration

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
@@ -26,7 +26,7 @@
 -DBW_HOME=%%TIBCO_HOME%%/%%BW_HOME%%
 -Dbw.governance.enabled=false
 -classpath
-%%TIBCO_HOME%%/tools/p2director/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
+%%ECLIPSE_PLUGINS%%/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
 org.eclipse.equinox.launcher.Main
 -dev
 -configuration


### PR DESCRIPTION
****What's this Pull request about?
Externalise path of Eclipse Equinox Launcher jar - path as a maven property "eclipse.plugins".
Having externalized eclipse plugins path helps during the maven test phase executed in a docker container with bwce-runtime base (CI steps).
****Which Issue(s) this Pull Request will fix?
No issue - new feature needed for CI/CD pipeline

****Does this pull request maintain backward compatibility?
Yes - if the "eclipse.plugins" property is not defined in a project the default path would be applied

****How this pull request has been tested?
-with/without new property in a local environment with a studio
-with/without new property in docker container without studio/ just equinox launcher jar file


****Screenshots (if appropriate)

Screenshot(s) of the change

****Any background context or comments you want to provide?

Needed for CI/CD pipeline - Test Unit executed in a docker container (bwce-runtime image) + equinox launcher jar