### PR TITLE
#352 BW6 6.5.1 + Maven plugin 2.2 : The Java class is not found in the classpath #361

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -211,9 +212,10 @@ public class TestFileParser {
 	}
 	
 	
-		public List<String> collectMockActivities(String contents){
+		public HashSet<String> collectSkipInitActivities(String contents){
 		InputStream is = null;
-		List<String> mockActivities = new ArrayList<>();
+		HashSet<String> skipInitActivitiesSet = new HashSet<String>();
+		
 		try {
 			
 			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -231,6 +233,8 @@ public class TestFileParser {
 					if ("ProcessNode".equals(el.getNodeName())) 
 					{
 						String processId = el.getAttributes().getNamedItem("Id").getNodeValue();
+						String key = "-D"+processId+"=true";
+						skipInitActivitiesSet.add(key);
 						NodeList childNodes = el.getChildNodes();
 						for (int j = 0; j < childNodes.getLength(); j++) 
 						{
@@ -244,7 +248,7 @@ public class TestFileParser {
 									if(!disableMocking){
 										String activityName = cEl.getAttributes().getNamedItem("Name").getNodeValue();
 										if(null!=activityName){
-											mockActivities.add("-D"+processId+activityName+"=true");
+											skipInitActivitiesSet.add("-D"+processId+activityName+"=true");
 										}
 									}
 								}
@@ -266,7 +270,7 @@ public class TestFileParser {
 				e.printStackTrace();
 			}
 		}
-		return mockActivities;
+		return skipInitActivitiesSet;
 
 	}
 	

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/BWTestExecutor.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/BWTestExecutor.java
@@ -3,6 +3,7 @@ package com.tibco.bw.maven.plugin.test.setuplocal;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -13,6 +14,7 @@ import com.tibco.bw.maven.plugin.test.helpers.BWTestConfig;
 import com.tibco.bw.maven.plugin.test.helpers.TestFileParser;
 import com.tibco.bw.maven.plugin.test.rest.BWTestRunner;
 import com.tibco.bw.maven.plugin.utils.BWFileUtils;
+
 
 
 public class BWTestExecutor 
@@ -58,7 +60,13 @@ public class BWTestExecutor
 		
 	}
 	
-	public void collectMockActivityName() throws Exception,FileNotFoundException
+	/**
+	 * This method is used to collect the all mock activities and subprocess whose activities "init()" lifecycle wants
+	 * to skip at runtime. 
+	 * @throws Exception
+	 * @throws FileNotFoundException
+	 */
+	public void collectSkipInitActivityName() throws Exception,FileNotFoundException
 	{
 		List<MavenProject> projects = BWTestConfig.INSTANCE.getSession().getProjects();
 		for( MavenProject project : projects )
@@ -69,11 +77,11 @@ public class BWTestExecutor
 				List<File> files = BWFileUtils.getEntitiesfromLocation( baseDir.toString() , "bwt");
 				for( File file : files )
 				{
-					List<String> tempList = new ArrayList<String>();
+					HashSet<String> tempSkipSet = new HashSet<String>();
 					String assertionxml = FileUtils.readFileToString( file );
-					tempList = TestFileParser.INSTANCE.collectMockActivities(assertionxml);
-					if(!tempList.isEmpty()){
-						mockActivity.addAll(tempList);
+					tempSkipSet = TestFileParser.INSTANCE.collectSkipInitActivities(assertionxml);
+					if(!tempSkipSet.isEmpty()){
+						mockActivity.addAll(tempSkipSet);
 						BWTestExecutor.INSTANCE.setMockActivityList(mockActivity);;
 						
 					}
@@ -87,7 +95,7 @@ public class BWTestExecutor
 	private void initialize() throws Exception
 	{
 		
-		collectMockActivityName();
+		collectSkipInitActivityName();
 		EngineLaunchConfigurator config = new EngineLaunchConfigurator();
 		config.loadConfiguration();
 		


### PR DESCRIPTION
****What's this Pull request about?

In BW case, all activities get initialized using the init function but in case of unit testing, we need to initialize the activities from the subprocesses which are under unit testing only. So with this code we are passing the subprocesses which are under unit testing as an environment variables to the BW runtime and at the BW runtime while initializing the activity the check is sone which ensures to initialize those activities which are passed as env variables. BW runtime fix has been done with BW 6.6.0
****Which Issue(s) this Pull Request will fix?

#352 BW6 6.5.1 + Maven plugin 2.2 : The Java class is not found in the classpath

****Does this pull request maintain backward compatibility?

****How this pull request has been tested?

Attach project with Issue has been tested