### PR TITLE
#341-Unit Test Successful Even Though Mapper Mock File Has Bad Value

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/rest/BWTestRunner.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/rest/BWTestRunner.java
@@ -121,11 +121,15 @@ public class BWTestRunner
 			
 			TestSuiteResultDTO resultDTO = r.path("tests").path("runtest").request(MediaType.APPLICATION_XML).post(Entity.entity(suite, MediaType.APPLICATION_XML) , TestSuiteResultDTO.class);
 			
-			result.getModuleResult().add(resultDTO);
-			
-			int failures = printTestResults(resultDTO);
-			
-			return failures;
+			if( null != resultDTO ){
+				result.getModuleResult().add(resultDTO);
+				int failures = printTestResults(resultDTO);
+				return failures;
+			}
+			else{
+				throw new MojoFailureException("An Exception occurred");
+			}
+		
 
 			
 		


### PR DESCRIPTION
****What's this Pull request about?

Initially, In case of Assertion and Mocking, if the exception occurred while assertion  or mocking expression evaluation then we were not throwing any exception from BW side. Now if in case of errors BW will return null result and in maven we have checked if the result in null then throw  MojoFailure Exception

****Which Issue(s) this Pull Request will fix?
#341-Unit Test Successful Even Though Mapper Mock File Has Bad Value


****Does this pull request maintain backward compatibility?
yes



