### PR TITLE
Adding changes for AMBW-36989

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
@@ -47,7 +47,7 @@ public class TestFileParser {
 
 	
 	@SuppressWarnings({ "unchecked" })
-	public void collectAssertions(String contents , TestSuiteDTO suite ) throws Exception,FileNotFoundException
+	public void collectAssertions(String contents , TestSuiteDTO suite , String baseDirectoryPath ) throws Exception,FileNotFoundException
 	{
 		
 		
@@ -151,6 +151,11 @@ public class TestFileParser {
 											if ("MockOutputFilePath".equals(e1.getNodeName()))
 											{
 												String mockOutputFilePath = e1.getTextContent();
+												File file = new File(mockOutputFilePath);
+												if(!file.isAbsolute()){
+													BWTestConfig.INSTANCE.getLogger().info("Provided Mock File path is relative "+file.getPath());
+													mockOutputFilePath = baseDirectoryPath.concat(mockOutputFilePath);
+												}
 												if(!disableMocking){
 													boolean isValidFile = validateMockXMLFile(mockOutputFilePath);
 													if(isValidFile){

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/rest/AssertionsLoader.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/rest/AssertionsLoader.java
@@ -38,7 +38,7 @@ public class AssertionsLoader
 			
 			String assertionxml = FileUtils.readFileToString( file );
 			
-			TestFileParser.INSTANCE.collectAssertions(assertionxml , suite);
+			TestFileParser.INSTANCE.collectAssertions(assertionxml , suite ,project.getBasedir().getAbsolutePath());
 			
 		}
 		


### PR DESCRIPTION
****What's this Pull request about?

This pull request has changes to support relative path for mock files. With this enhancement user can put there mock file in "Test" folder of project itself. So that it can be shared across the machines with projects 
****Which Issue(s) this Pull Request will fix?
#391-Provide relative path for the mock file locations

****Does this pull request maintain backward compatibility?
Yes

****How this pull request has been tested?

1. Create corresponding mock file and keep it in "Test" folder.
2. Provide the relative mock file path for corresponding mocked activity.
3. Run the "test" goal on project.




