### PR TITLE
"goldInputFromFile" field is not getting initialized per test case

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
@@ -42,7 +42,6 @@ public class TestFileParser {
 	
 	boolean disableAssertions = false;
 	
-	String goldInputFromFile = "false";
 
 	private TestFileParser() {
 
@@ -52,7 +51,7 @@ public class TestFileParser {
 	@SuppressWarnings({ "unchecked" })
 	public void collectAssertions(String contents , TestSuiteDTO suite , String baseDirectoryPath ) throws Exception,FileNotFoundException
 	{
-		
+		String goldInputFromFile = "false";
 		
 		InputStream is = null;
 		try {


### PR DESCRIPTION
****What's this Pull request about?

"goldInputFromFile" field is not getting initialized per test case

****Which Issue(s) this Pull Request will fix?

This is internal finding, hence there is no issue created for the same

****Does this pull request maintain backward compatibility?
Yes

****How this pull request has been tested?
By running multiple test cases with "goldInputFromFile" as checked .




