### PR TITLE
 Code coverage report should show covered activity name

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/coverage/ProcessCoverageStatsGenerator.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/coverage/ProcessCoverageStatsGenerator.java
@@ -30,7 +30,6 @@ public class ProcessCoverageStatsGenerator
 			}
 			stats.addActivities( cov.getActivities().size() );
 			stats.addActivitiesCovered( cov.getActivitiesExec().size() );
-
 			stats.addTransition( cov.getTransitions().size() );
 			stats.addTransitionCovered( cov.getTransitionExec().size());
 
@@ -39,6 +38,7 @@ public class ProcessCoverageStatsGenerator
 			pstat.setProcessName( cov.getProcessName() );
 			pstat.setTotalActivities( cov.getActivities().size() );
 			pstat.setCoveredActivities( cov.getActivitiesExec().size() );
+			pstat.addCoveredActivitiesName( cov.getActivitiesExec() );
 			pstat.setTotalTransitions( cov.getTransitions().size() );
 			pstat.setCoveredTransitions( cov.getTransitionExec().size());
 			processStats.add(pstat);
@@ -77,6 +77,7 @@ public class ProcessCoverageStatsGenerator
 		private int coveredTransitions;
 		
 		private int coveredActivities;
+		
 		
 		public void addModule( String module )
 		{
@@ -213,7 +214,6 @@ public class ProcessCoverageStatsGenerator
 
 			return  format.format(success) + "%  (" + covered + " / "  + total + ")";
 		}
-
 		
 	}
 	
@@ -231,6 +231,7 @@ public class ProcessCoverageStatsGenerator
 		
 		private int coveredActivities;
 		
+		private List<String> coveredActivitiesName = new ArrayList<String>();
 		
 		public String getActivityStat()
 		{
@@ -327,6 +328,14 @@ public class ProcessCoverageStatsGenerator
 
 		public void setCoveredActivities(int coveredActivities) {
 			this.coveredActivities = coveredActivities;
+		}
+		
+		public List<String> getCoveredActivitiesName() {
+			return coveredActivitiesName;
+		}
+
+		public void addCoveredActivitiesName(List<String> coveredActivityName) {
+			coveredActivitiesName.addAll(coveredActivityName);
 		}
 		
 		

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/CodeCoverageReportGenerator.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/CodeCoverageReportGenerator.java
@@ -145,6 +145,8 @@ public class CodeCoverageReportGenerator
 			sinkHeader( sink, "Module" );
 
 			sinkHeader( sink, "Process" );
+			
+			sinkHeader( sink, "Activity Name" );
 
 			sinkHeader( sink,"Activity %" );
 
@@ -161,6 +163,8 @@ public class CodeCoverageReportGenerator
 			        sinkCell( sink, stat.getModuleName() );
 
 			        sinkCell( sink, stat.getProcessName() );
+			        
+			        sinkCell( sink, stat.getCoveredActivitiesName().toString() );
 
 			        sinkCell( sink, stat.getActivityStat() );
 


### PR DESCRIPTION

****What's this Pull request about?

Currently BW Coverage report shows the covered activity count and activity percentage. This pull request has changes to list out covered activities name as well in coverage report.

****Which Issue(s) this Pull Request will fix?
#417 Code coverage report should show covered activity name

****Does this pull request maintain backward compatibility?
NA

****How this pull request has been tested?
By generating the BW coverage report

Mention the test scenarios.

****Screenshots (if appropriate)

Screenshot(s) of the change

![CoverageReport](https://user-images.githubusercontent.com/31987978/76197689-9e1f3480-6212-11ea-92f3-f8bf1b5f0eeb.JPG)



