### PR TITLE
# 419 In Case of test failure, show provided input and gold input on logs and reports

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
@@ -44,6 +44,9 @@ public class BWTestMojo extends AbstractMojo {
     @Parameter( property = "engineDebugPort" , defaultValue = "8090" )
     private int engineDebugPort;
     
+    @Parameter( property = "showFailureDetails" , defaultValue = "false" )
+    private boolean showFailureDetails;
+    
     
     
     
@@ -184,6 +187,8 @@ public class BWTestMojo extends AbstractMojo {
 		TestFileParser.INSTANCE.setdisbleMocking(disableMocking);
 		
 		TestFileParser.INSTANCE.setdisbleAssertions(disableAssertions);
+		
+		TestFileParser.INSTANCE.setshowFailureDetails(showFailureDetails);
 		
 		BWTestExecutor.INSTANCE.setEngineDebugPort(engineDebugPort);
 

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/AssertionDTO.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/AssertionDTO.java
@@ -15,6 +15,18 @@ public class AssertionDTO implements Serializable {
 	private String expression;
 	private ConditionLanguageDTO language;
 	private String activityId;
+	private String goldInput;
+	private String assertionMode;
+	private String startElementNameTag;
+	private String endElementNameTag;
+
+	public String getGoldInput() {
+		return goldInput;
+	}
+
+	public void setGoldInput(String goldInput) {
+		this.goldInput = goldInput;
+	}
 
 	@XmlElement
 	public String getProcessId() {
@@ -61,6 +73,30 @@ public class AssertionDTO implements Serializable {
 	public void setActivityId(String activityId) 
 	{
 		this.activityId = activityId;
+	}
+
+	public String getAssertionMode() {
+		return assertionMode;
+	}
+
+	public void setAssertionMode(String assertionMode) {
+		this.assertionMode = assertionMode;
+	}
+
+	public String getStartElementNameTag() {
+		return startElementNameTag;
+	}
+
+	public void setStartElementNameTag(String startElementNameTag) {
+		this.startElementNameTag = startElementNameTag;
+	}
+
+	public String getEndElementNameTag() {
+		return endElementNameTag;
+	}
+
+	public void setEndElementNameTag(String endElementNameTag) {
+		this.endElementNameTag = endElementNameTag;
 	}
 
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/AssertionResultDTO.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/AssertionResultDTO.java
@@ -14,6 +14,11 @@ public class AssertionResultDTO implements Serializable
 	private String activityName;
 	private String assertionStatus;
 	private String message;
+	private String goldInput;
+	private String assertionMode;
+	private String startElementNameTag;
+	private String endElementNameTag;
+	private String activityOutput;
 	
 	@XmlElement
 	public String getInstanceId() 
@@ -57,6 +62,47 @@ public class AssertionResultDTO implements Serializable
 	public void setMessage(String message) 
 	{
 		this.message = message;
+	}
+
+	public String getGoldInput() {
+		return goldInput;
+	}
+
+	public void setGoldInput(String goldInput) {
+		this.goldInput = goldInput;
+	}
+
+	public String getAssertionMode() {
+		return assertionMode;
+	}
+
+	public void setAssertionMode(String assertionMode) {
+		this.assertionMode = assertionMode;
+	}
+
+	public String getStartElementNameTag() {
+		return startElementNameTag;
+	}
+
+	public void setStartElementNameTag(String startElementNameTag) {
+		this.startElementNameTag = startElementNameTag;
+	}
+
+	public String getEndElementNameTag() {
+		return endElementNameTag;
+	}
+
+	public void setEndElementNameTag(String endElementNameTag) {
+		this.endElementNameTag = endElementNameTag;
+	}
+
+	@XmlElement
+	public String getActivityOutput() {
+		return activityOutput;
+	}
+
+	public void setActivityOutput(String activityOutput) {
+		this.activityOutput = activityOutput;
 	}
 
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/TestSuiteDTO.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/TestSuiteDTO.java
@@ -17,6 +17,8 @@ public class TestSuiteDTO implements Serializable
 	private List testSetList = new ArrayList();
 
 	private ModuleInfoDTO moduleInfo;
+	
+	private boolean showFailureDetails;
 
 	
 	@SuppressWarnings("rawtypes")
@@ -41,6 +43,15 @@ public class TestSuiteDTO implements Serializable
 	public void setModuleInfo(ModuleInfoDTO moduleInfo) 
 	{
 		this.moduleInfo = moduleInfo;
+	}
+	
+	@XmlElement (name = "showFailureDetails")
+	public boolean isShowFailureDetails() {
+		return showFailureDetails;
+	}
+
+	public void setShowFailureDetails(boolean showFailureDetails) {
+		this.showFailureDetails = showFailureDetails;
 	}
 
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/TestSuiteResultDTO.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/dto/TestSuiteResultDTO.java
@@ -18,6 +18,8 @@ public class TestSuiteResultDTO implements Serializable
 
 	private ModuleInfoDTO moduleInfo;
 	
+	private boolean showFailureDetails;
+	
 	@SuppressWarnings("rawtypes")
 	private List testSetResult = new ArrayList();
 
@@ -59,6 +61,15 @@ public class TestSuiteResultDTO implements Serializable
 	public void setModuleInfo(ModuleInfoDTO moduleInfo) 
 	{
 		this.moduleInfo = moduleInfo;
+	}
+	
+	@XmlElement(name="showFailureDetails")
+	public boolean getshowFailureDetails() {
+		return showFailureDetails;
+	}
+
+	public void setshowFailureDetails(boolean showFailureDetails) {
+		this.showFailureDetails = showFailureDetails;
 	}	
 	
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestSuiteReportParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestSuiteReportParser.java
@@ -20,6 +20,7 @@ public class BWTestSuiteReportParser
 
 	private CompleteReportDTO completeResult ;
 	private Summary summary;
+	private boolean showFailureDetails = false;
 	private Map<String, PackageTestDetails> packageMap = new HashMap<>();
 	
 	public BWTestSuiteReportParser( CompleteReportDTO result )
@@ -45,7 +46,8 @@ public class BWTestSuiteReportParser
 		for( int count = 0 ; count < completeResult.getModuleResult().size() ; count++ )
 		{
 			TestSuiteResultDTO result = (TestSuiteResultDTO) completeResult.getModuleResult().get( count );
-		
+			
+			setShowFailureDetails( result.getshowFailureDetails());
 		
 			for( int i =0 ; i < result.getTestSetResult().size() ; i++ )
 			{
@@ -104,7 +106,14 @@ public class BWTestSuiteReportParser
 						AssertionResultDTO aresult = (AssertionResultDTO) testcase.getAssertionResult().get(  assercount );
 						if( aresult.getAssertionStatus().equals("failed"))
 						{
+							StringBuilder assertionFailureDataBuilder = new StringBuilder();
 							fileDetails.addAssertionFailure(aresult.getActivityName() );
+							assertionFailureDataBuilder.append(" Assertion Failed For Activity with name "+"["+aresult.getActivityName()+"]");
+							assertionFailureDataBuilder.append(" [Reason] - Validation failed against Gold file. Please compare Activity output against Gold output values");
+							assertionFailureDataBuilder.append(" [Activity Output:  "+aresult.getActivityOutput()+"]");
+							assertionFailureDataBuilder.append(" [Gold Output:  "+aresult.getGoldInput()+"]");
+							fileDetails.addFailureData(assertionFailureDataBuilder.toString());
+							
 						}
 					}
 					
@@ -138,6 +147,15 @@ public class BWTestSuiteReportParser
 	public void setSummary(Summary summary) 
 	{
 		this.summary = summary;
+	}
+
+
+	public boolean isShowFailureDetails() {
+		return showFailureDetails;
+	}
+
+	public void setShowFailureDetails(boolean showFailureDetails) {
+		this.showFailureDetails = showFailureDetails;
 	}
 
 
@@ -348,6 +366,7 @@ public class BWTestSuiteReportParser
 		private int failures;
 		private int errors;
 		private List<String> assertionFailures = new ArrayList<>();
+		private List<String> failureDataList = new ArrayList<>();
 		
 		public ProcessFileTestDetails()
 		{
@@ -409,6 +428,14 @@ public class BWTestSuiteReportParser
 		public void addAssertionFailure( String str)
 		{
 			assertionFailures.add(str);
+		}
+
+		public List<String> getFailureData() {
+			return failureDataList;
+		}
+
+		public void addFailureData(String failureData) {
+			failureDataList.add(failureData);
 		}
 		
 	}


### PR DESCRIPTION


****What's this Pull request about?

In Case of test failure, show provided input and gold input on logs and reports

****Which Issue(s) this Pull Request will fix?

#419 In Case of test failure, show provided input and gold input on logs and reports

****Does this pull request maintain backward compatibility?
NA

This feature is property based. If showFailureDetails = true then only it will sow the failure details in the logs and reports as well



