### PR TITLE
For bwear add maven dependencies to osgi.bundles.

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/ConfigFileGenerator.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/ConfigFileGenerator.java
@@ -10,10 +10,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 
 import com.tibco.bw.maven.plugin.test.helpers.BWTestConfig;
@@ -40,7 +42,21 @@ public class ConfigFileGenerator
 			}
 			
 			List<MavenProject> projects =  BWTestConfig.INSTANCE.getSession().getProjects();
+
+			for( MavenProject project : projects ) {
+				if (project.getPackaging().equals("bwear")) {
+
+					Set<Artifact> artifacts = project.getDependencyArtifacts();
+					for(Artifact artifact:artifacts) {
+						if(!"provided".equals(artifact.getScope())) {
+							builder.append( "," );
+							addReference(builder, artifact.getFile(), artifact.getArtifactId());
+						}
+					}
+				}
+			}
 			
+
 			for( MavenProject project : projects )
 			{
 				if( project.getPackaging().equals("bwmodule") || project.getPackaging().equals("bwear"))

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/ConfigFileGenerator.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/ConfigFileGenerator.java
@@ -44,11 +44,11 @@ public class ConfigFileGenerator
 			List<MavenProject> projects =  BWTestConfig.INSTANCE.getSession().getProjects();
 
 			for( MavenProject project : projects ) {
-				if (project.getPackaging().equals("bwear")) {
+				if (project.getPackaging().equals("bwmodule") || project.getPackaging().equals("bwear")) {
 
 					Set<Artifact> artifacts = project.getDependencyArtifacts();
 					for(Artifact artifact:artifacts) {
-						if(!"provided".equals(artifact.getScope())) {
+						if(!"provided".equals(artifact.getScope()) || !(artifact.getFile().getName().indexOf("com.tibco.bw.palette.shared") != -1)) {
 							builder.append( "," );
 							addReference(builder, artifact.getFile(), artifact.getArtifactId());
 						}


### PR DESCRIPTION
****What's this Pull request about?

When you use a shared module as a dependency in application pom.xml, we need to add this jar in osgi.bundles list to avoid Unresolved requirement: Require-Capability: com.tibco.bw.module; error.

****Which Issue(s) this Pull Request will fix?

https://github.com/TIBCOSoftware/bw6-plugin-maven/issues/444

****Does this pull request maintain backward compatibility?

Yes

****How this pull request has been tested?

Yes. I created a shared module which contains a schema file and I referred this shared module into an application. I build the shared module as a jar using maven plugin and publish the jar into maven local. In the application pom.xml I added dependency to this shared module.

****Screenshots (if appropriate)

Screenshot(s) of the change

****Any background context or comments you want to provide?

In ConfigFileGenerator.java, generateConfig method, I iterated all project and project dependencies to add them in the builder variable.


