### PR TITLE
Do not include depending shared module inside the jar file

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
@@ -183,20 +183,21 @@ public class BWModulePackageMojo extends AbstractMojo {
 				continue;
 			}
 			
-			
+			boolean isSharedModule = false;
 			Manifest mf = ManifestParser.parseManifestFromJAR( file);
 			for( Object str : mf.getMainAttributes().keySet())
 			{
 				getLog().debug( str.toString() );
-				if( "TIBCO-BW-SharedModule".equals(str.toString() ))
-				{
-					continue;
-					
+				if("TIBCO-BW-SharedModule".equals(str.toString())) {
+					isSharedModule = true;
+					break;
 				}
 			}
-			getLog().debug("Dependency added with name " + file.toString());
-			jarArchiver.addFile(file, "lib/" + file.getName());
-			buffer.append(",lib/" + file.getName());
+			if(!isSharedModule) {
+				getLog().debug("Dependency added with name " + file.toString());
+				jarArchiver.addFile(file, "lib/" + file.getName());
+				buffer.append(",lib/" + file.getName());
+			}
 		}
 
 		String bundleClasspath = manifest.getMainAttributes().getValue(Constants.BUNDLE_CLASSPATH);


### PR DESCRIPTION
Skip shared modules so they are not embedded in the jar file.

****What's this Pull request about?

Fixing #478 by not embedding shared modules inside a shared module jar

****Which Issue(s) this Pull Request will fix?

#478 

****Does this pull request maintain backward compatibility?

Yes
