### PR TITLE
 Improvement on starting BW Engine

### DIFF
--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/environment.properties
@@ -34,4 +34,5 @@ x86_64
 -nl
 en_US
 -consoleLog
+-console
 -clean

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
@@ -37,4 +37,5 @@ x86_64
 -nl
 en_US
 -consoleLog
+-console
 -clean

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
@@ -40,4 +40,5 @@ x86_64
 -nl
 en_US
 -consoleLog
+-console
 -clean


### PR DESCRIPTION
****What's this Pull request about?

Improvement on BW Engine started in Test Mode:

- wait maximum 5 min to launch the BW engine;
- catch 'BW Application is impaired' and shutdown the BW Engine
- if an error occurs on launching BW Engine, issue 'la' osgi command for more details about error
- use maven logger instead of System.out

****Which Issue(s) this Pull Request will fix?
N/A

****Does this pull request maintain backward compatibility?
YES

****How this pull request has been tested?
Running unit test for application with errors

****Screenshots (if appropriate)

Screenshot(s) of the change

****Any background context or comments you want to provide?

The proposed change is very useful in CI/CD context when the build and unit tests are ran on a Jenkins environment, unattended and in case when the application doesn't starts, the job keeps running indefinably. Furthermore, even you kill the job, the BWEngine is running in background and if you want to run another job you will need to kill, manually, the bw engine process.



