### PR TITLE
Shared modules are loaded when runs unit test if Bundle-Version doesn't ends with .qualifier

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
@@ -96,7 +96,8 @@ public class BWModulePackageMojo extends AbstractMojo {
             getLog().info("Updated the Manifest version ");
             
             ManifestWriter.updateManifestVersion(project, manifest);
-            updateManifestVersion();
+            getLog().info("The OSGi version is " + manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION) + " for Maven version of " + project.getVersion());
+            //updateManifestVersion();
             
             getLog().info("Removing the externals entries if any. ");
             removeExternals();
@@ -318,12 +319,14 @@ public class BWModulePackageMojo extends AbstractMojo {
     	return manifest.getMainAttributes().getValue(Constants.TIBCO_SHARED_MODULE) == null ? false : true;
     }
 
+/*
     private void updateManifestVersion() {
     	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
     	String qualifierVersion = VersionParser.getcalculatedOSGiVersion(version);
-    	getLog().info("The OSGi verion is " + qualifierVersion + " for Maven version of " + version);
+		getLog().info("The OSGi version is " + qualifierVersion + " for Maven version of " + version);
     	manifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, qualifierVersion);
-    }
+	}
+*/
 
     private void removeExternals() {
     	String bundlePath = manifest.getMainAttributes().getValue(Constants.BUNDLE_CLASSPATH);

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/osgi/helpers/ManifestWriter.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/osgi/helpers/ManifestWriter.java
@@ -42,9 +42,14 @@ public class ManifestWriter {
         	projectVersion = projectVersion.replace("-SNAPSHOT", ".qualifier");
         	projectVersion = getManifestVersion(mf, projectVersion);
         }
+
+        //For shared modules (external dependencies from pom.xml), in order to be loaded by BWEngine, the Bundle-Version should ends with .qualifier
+        if(BWProjectUtils.getModuleType(mf) == MODULE.SHAREDMODULE) {
+            projectVersion += "." + VersionParser.QUALIFIER;
+        }
         
     	attributes.put(Name.MANIFEST_VERSION, projectVersion);
-        attributes.putValue("Bundle-Version", projectVersion );
+        attributes.putValue(Constants.BUNDLE_VERSION, projectVersion );
 
         //Updating provide capability for Shared Modules
 //        if(BWProjectUtils.getModuleType(mf) == MODULE.SHAREDMODULE){


### PR DESCRIPTION
****What's this Pull request about?

First of all, I opened this issue at TIBCO Support (case number: 01862783) and the resolution was: ".qualifier is a mandatory for the bundle version in BW"

I created a shared module (which contains few schema used in all applications).
We build shared module using maven plugin and placed the resulting jar in Local Maven Repository. The applications have in <dependencies> section an entry to this jar. Unfortunate, when running unit tests, the shared module is not loaded unless in, shared module MANIFEST.MF, the value of Bundle-Version is in format: 1.0.0.qualifier.

We tried with Bundle-Version as 1.0.0 and 1.0.0.202004xxx without success.

****Which Issue(s) this Pull Request will fix?

https://github.com/TIBCOSoftware/bw6-plugin-maven/issues/464

****Does this pull request maintain backward compatibility?
YES

****How this pull request has been tested?

1. unzip unit-testing-sample.zip into a new folder (workspace folder)
2. build logging-library shared module (go to project folder and mvn clean package install)
3. build and run unit tests for unit-test-1 application (go to workspace folder and mvn clean package -f unit-test-1.parent\pom.xml).

If you perform above steps with bw6-maven-plugin (build from master 2.7.0), you will receive a "TIBCO-THOR-FRWK-300019: BW Application [unit-test-1:1.0] is impaired" and nothing else happens.

If you perform above steps with proposed by me, the unit tests are running ok.

****Screenshots (if appropriate)

Screenshot(s) of the change

****Any background context or comments you want to provide?

This version is running in our production environment from over 2 months without any problem.



