### PR TITLE
Generate swagger json for REST Services

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/lifecycle/BWProjectLifeCycleListener.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/lifecycle/BWProjectLifeCycleListener.java
@@ -32,14 +32,14 @@ public class BWProjectLifeCycleListener extends AbstractMavenLifecycleParticipan
 	public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
 		logger.info("Starting Maven Build for BW6 Project.................................");
 		logger.info("Checking for In-Project JAR dependencies if any and Pushing them to Local Maven Repository");
-		logger.debug("Cleaning existing JARs from Mavne Repository");
+		logger.debug("Cleaning existing JARs from Maven Repository");
 		File file = new File(session.getLocalRepository().getBasedir() + "/tempbw");
 		try {
 			if(file.exists()) {
 				FileUtils.deleteDirectory(file) ;	
 			}
 		} catch(Exception e) {
-			logger.error("Failed to clean the existing bwtemp group in Maven Repository.");
+			logger.error(String.format("Failed to clean the existing {} group in Maven Repository.", file.getAbsolutePath()), e);
 		}
 
 		List<MavenProject> projects = session.getProjects();

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
@@ -333,7 +333,7 @@ public class BWModulePackageMojo extends AbstractMojo {
     private void updateManifestVersion() {
     	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
     	String qualifierVersion = VersionParser.getcalculatedOSGiVersion(version, qualifierReplacement);
-    	getLog().info("The OSGi verion is " + qualifierVersion + " for Maven version of " + version);
+    	getLog().info("The OSGi version is " + qualifierVersion + " for Maven version of " + version);
     	manifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, qualifierVersion);
     }
 

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/swagger/SwaggerGenerator.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/swagger/SwaggerGenerator.java
@@ -1,0 +1,206 @@
+package com.tibco.bw.maven.plugin.swagger;
+
+import com.tibco.bw.maven.plugin.test.helpers.BWTestConfig;
+import com.tibco.bw.maven.plugin.test.setuplocal.*;
+import com.tibco.bw.maven.plugin.utils.BWFileUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.xml.sax.InputSource;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.List;
+
+
+@Mojo(name = "bwdocs", defaultPhase = LifecyclePhase.PACKAGE)
+public class SwaggerGenerator extends AbstractMojo {
+    @Parameter(defaultValue="${session}", readonly=true)
+    private MavenSession session;
+
+    @Parameter(defaultValue="${project}", readonly=true)
+    private MavenProject project;
+
+    @Parameter( property = "engineStartupWaitTime" , defaultValue = "2" )
+    private int engineStartupWaitTime;
+
+    @Parameter( property = "engineDebugPort" , defaultValue = "8090" )
+    private int engineDebugPort;
+
+    //@Parameter( property = "osgiCommands" )
+    private List<String> osgiCommands = Arrays.asList("lrestdoc");
+
+    @Parameter( property = "restApiDocPort" , defaultValue = "7777" )
+    private int restApiDocPort;
+
+    @Parameter( property = "swaggerOutputFile" , defaultValue = "swagger.json" )
+    private String swaggerOutputFile;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+
+        if(project.getPackaging().equals("bwear")) {
+            try {
+                if (!verifyParameters()) {
+                    return;
+                } else {
+                    initialize();
+
+                    runEngine();
+
+                    Thread.sleep(2000);
+
+                    OSGICommandExecutor cmdExecutor = new OSGICommandExecutor();
+
+                    for(String command : osgiCommands)
+                    {
+                        BWTestConfig.INSTANCE.getLogger().info("------------------------------------------------------------------------");
+                        BWTestConfig.INSTANCE.getLogger().info("## Executing OSGi command ("+ command +") ##");
+                        BWTestConfig.INSTANCE.getLogger().info("------------------------------------------------------------------------");
+
+                        cmdExecutor.executeCommand(command);
+                    }
+
+                    generateSwagger();
+                }
+            }
+            catch(Exception e )
+            {
+                getLog().error(e);
+                throw new MojoExecutionException("Failed to generate Swagger file", e);
+            }
+            finally
+            {
+                if( BWTestConfig.INSTANCE.getEngineProcess() != null )
+                {
+                    BWTestConfig.INSTANCE.getEngineProcess().destroyForcibly();
+                }
+                if( BWTestConfig.INSTANCE.getConfigDir() != null )
+                {
+                    BWTestConfig.INSTANCE.getConfigDir().delete();
+                }
+
+            }
+        }
+    }
+
+
+    private boolean verifyParameters() throws XPathExpressionException
+    {
+        String tibcoHome = project.getProperties().getProperty("tibco.Home");
+        String bwHome = project.getProperties().getProperty("bw.Home");
+
+        if( tibcoHome == null || tibcoHome.isEmpty() || bwHome == null || bwHome.isEmpty() )
+        {
+            getLog().info( "------------------------------------------------------------------------" );
+            getLog().info( "TIBCO Home or BW Home is not provided. Skipping Swagger Generation Phase.");
+            getLog().info( "------------------------------------------------------------------------" );
+
+            return false;
+        }
+
+        if(!checkForSwaggers()) {
+            getLog().info( "-----------------------------------------------------------" );
+            getLog().info( "No REST Project detected. Skipping Swagger Generation Phase.");
+            getLog().info( "-----------------------------------------------------------" );
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean checkForSwaggers() throws XPathExpressionException
+    {
+        List<MavenProject> projects = session.getProjects();
+
+        for( MavenProject project : projects )
+        {
+            if( project.getPackaging().equals("bwmodule") )
+            {
+                List<File> files = BWFileUtils.getEntitiesfromLocation( project.getBasedir().toString() , "bwm");
+                if( files.size() > 0 )
+                {
+                    final XPathFactory factory = XPathFactory.newInstance();
+                    final XPath xpath = factory.newXPath();
+                    XPathExpression expression = xpath.compile("boolean(//*[local-name()='binding'][@*[local-name()='type' and .='rest:RestServiceBinding']])");
+
+                    for (File file:files) {
+                        getLog().info("Check " + file + " for REST Services");
+                        InputSource is = new InputSource(file.getAbsolutePath());
+                        String eval = expression.evaluate(is);
+                        if (Boolean.valueOf(eval)) {
+                            getLog().info("   Found REST Service into file " + file);
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        getLog().info( "-------------------------------------------------------" );
+        getLog().info( "No Swagger files exist. ");
+        getLog().info( "-------------------------------------------------------" );
+
+        return false;
+    }
+
+
+    private void initialize() throws Exception
+    {
+        String tibcoHome = project.getProperties().getProperty("tibco.Home");
+        String bwHome = project.getProperties().getProperty("bw.Home");
+
+        BWTestExecutor.INSTANCE.setEngineDebugPort(engineDebugPort);
+
+        BWTestExecutor.INSTANCE.setRestApiDocPort(restApiDocPort);
+
+        BWTestExecutor.INSTANCE.setOsgiCommands(osgiCommands);
+
+        BWTestExecutor.INSTANCE.setSkipInitMainProcessActivities(true);
+
+        BWTestExecutor.INSTANCE.setSkipInitAllNonTestProcessActivities(true);
+
+        BWTestConfig.INSTANCE.reset();
+
+        BWTestConfig.INSTANCE.init(  tibcoHome , bwHome , session, project , getLog() );
+
+        getLog().info( "" );
+        getLog().info( "-------------------------------------------------------" );
+        getLog().info( " Running BW Instance " );
+        getLog().info( "-------------------------------------------------------" );
+    }
+
+    private void runEngine() throws Exception
+    {
+        EngineLaunchConfigurator config = new EngineLaunchConfigurator();
+        config.loadConfiguration();
+
+        ConfigFileGenerator gen = new ConfigFileGenerator();
+        gen.generateConfig();
+
+        EngineRunner runner = new EngineRunner(engineStartupWaitTime, Arrays.asList());
+        runner.run();
+    }
+
+    private void generateSwagger() throws Exception
+    {
+        String swaggerUrl="http://localhost:" + restApiDocPort + "/" + project.getArtifactId() + "/swagger.json";
+
+        Files.copy(
+                new URL(swaggerUrl).openStream(),
+                Paths.get(swaggerOutputFile),
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+}

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
@@ -43,8 +43,11 @@ public class BWTestMojo extends AbstractMojo {
     
     @Parameter( property = "engineDebugPort" , defaultValue = "8090" )
     private int engineDebugPort;
-    
-    @Parameter( property = "showFailureDetails" , defaultValue = "true" )
+
+	@Parameter( property = "restApiDocPort" , defaultValue = "7777" )
+	private int restApiDocPort;
+
+	@Parameter( property = "showFailureDetails" , defaultValue = "true" )
     private boolean showFailureDetails;
     
     @Parameter( property = "testSuiteName" , defaultValue = "" )
@@ -204,7 +207,9 @@ public class BWTestMojo extends AbstractMojo {
 		TestFileParser.INSTANCE.setshowFailureDetails(showFailureDetails);
 		
 		BWTestExecutor.INSTANCE.setEngineDebugPort(engineDebugPort);
-		
+
+		BWTestExecutor.INSTANCE.setRestApiDocPort(restApiDocPort);
+
 		BWTestExecutor.INSTANCE.setEngineStartupWaitTime(engineStartupWaitTime);
 		
 		BWTestExecutor.INSTANCE.setOsgiCommands(osgiCommands);

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setupenterprise/BWEARTestPackagerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setupenterprise/BWEARTestPackagerMojo.java
@@ -557,7 +557,7 @@ public class BWEARTestPackagerMojo extends AbstractMojo {
     private void updateManifestVersion() {
     	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
     	String qualifierVersion = VersionParser.getcalculatedOSGiVersion(version, Constants.TIMESTAMP);
-    	getLog().info("The OSGi verion is " + qualifierVersion + " for Maven version of " + version);
+    	getLog().info("The OSGi version is " + qualifierVersion + " for Maven version of " + version);
     	manifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, qualifierVersion);
     }
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/BWTestExecutor.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/BWTestExecutor.java
@@ -28,6 +28,7 @@ public class BWTestExecutor
 	public static BWTestExecutor INSTANCE = new BWTestExecutor();
 	
 	int engineDebugPort;
+	int restApiDocPort;
 	int engineStartupWaitTime;
 	List<String> osgiCommands;
 	boolean skipInitMainProcessActivities;
@@ -186,7 +187,15 @@ public class BWTestExecutor
 	public int getEngineDebugPort(){
 		return engineDebugPort;
 	}
-	
+
+	public void setRestApiDocPort(int restApiDocPort){
+		this.restApiDocPort = restApiDocPort;
+	}
+
+	public int getRestApiDocPort(){
+		return restApiDocPort;
+	}
+
 	public List<String> getMockActivityList() {
 		return mockActivity;
 	}

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineLaunchConfigurator.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineLaunchConfigurator.java
@@ -109,6 +109,10 @@ public class EngineLaunchConfigurator
 				{
 					currentLine = currentLine.replace("%%ENGINE_DEBUG_PORT%%", String.valueOf(BWTestExecutor.INSTANCE.getEngineDebugPort()) );
 				}
+				if( currentLine.contains("%REST_DOCAPI_PORT%%"))
+				{
+					currentLine = currentLine.replace("%%REST_DOCAPI_PORT%%", String.valueOf(BWTestExecutor.INSTANCE.getRestApiDocPort()) );
+				}
 				if( currentLine.equals("-dev"))
 				{
 					if( isDev)

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineRunner.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineRunner.java
@@ -121,6 +121,7 @@ public class EngineRunner
 						if( line.contains( "TIBCO-THOR-FRWK-300019") && line.contains("impaired"))
 						{
 							isImpaired.set(true);
+							latch.countDown();
 						}
 			        }
 			        if(latch.getCount()>0){

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/environment.properties
@@ -16,10 +16,11 @@
 -Declipse.ignoreApp=true
 -Dosgi.noShutdown=true
 -Dorg.osgi.service.http.port=%%ENGINE_DEBUG_PORT%%
--Dlogback.configurationFile=%%TIBCO_HOME%%/bw/6.5/config/design/logback/logback.xml
+-Dlogback.configurationFile=%%TIBCO_HOME%%/%%BW_HOME%%/config/design/logback/logback.xml
 -DTIBCO_HOME=%%TIBCO_HOME%%
 -DBW_HOME=%%TIBCO_HOME%%/bw/6.5
 -Dbw.governance.enabled=false
+-Dbw.rest.docApi.port=%%REST_DOCAPI_PORT%%
 -classpath
 %%TIBCO_HOME%%/tools/p2director/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
 org.eclipse.equinox.launcher.Main

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
@@ -22,6 +22,7 @@
 -DTIBCO_HOME=%%TIBCO_HOME%%
 -DBW_HOME=%%TIBCO_HOME%%/%%BW_HOME%%
 -Dbw.governance.enabled=false
+-Dbw.rest.docApi.port=%%REST_DOCAPI_PORT%%
 -classpath
 %%TIBCO_HOME%%/tools/p2director/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
 org.eclipse.equinox.launcher.Main

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
@@ -25,6 +25,7 @@
 -DTIBCO_HOME=%%TIBCO_HOME%%
 -DBW_HOME=%%TIBCO_HOME%%/%%BW_HOME%%
 -Dbw.governance.enabled=false
+-Dbw.rest.docApi.port=%%REST_DOCAPI_PORT%%
 -classpath
 %%TIBCO_HOME%%/tools/p2director/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
 org.eclipse.equinox.launcher.Main


### PR DESCRIPTION
****What's this Pull request about?

Implement com.tibco.plugins:bw6-maven-plugin:bwdocs maven goal to generate REST service swagger

****Does this pull request maintain backward compatibility?

Yes

****How this pull request has been tested?

Run mvn package com.tibco.plugins:bw6-maven-plugin:bwdocs -DswaggerOutputFile=my-swagger.json for projects containing REST services and project not containing REST services


****Any background context or comments you want to provide?

I need this feature to publish swagger on a dedicated server (API Catalog).



