### PR TITLE
#563 bwTest: support for passing vm arguments, similar to surefire:test argLine

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/BWTestMojo.java
@@ -62,6 +62,9 @@ public class BWTestMojo extends AbstractMojo {
     @Parameter( property = "skipInitAllNonTestProcessActivities" , defaultValue = "false" )
     private boolean skipInitAllNonTestProcessActivities;
     
+    @Parameter( property = "customArgEngine"  )
+    private String customArgEngine;
+    
     public void execute() throws MojoExecutionException , MojoFailureException
     {
     	
@@ -213,7 +216,9 @@ public class BWTestMojo extends AbstractMojo {
 		
 		BWTestExecutor.INSTANCE.setSkipInitAllNonTestProcessActivities(skipInitAllNonTestProcessActivities);
 		
-    	BWTestConfig.INSTANCE.reset();
+		BWTestExecutor.INSTANCE.setCustomArgEngine(customArgEngine);
+    	
+		BWTestConfig.INSTANCE.reset();
     	
     	BWTestConfig.INSTANCE.setTestSuiteName(testSuiteName);
     	

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/BWTestExecutor.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/BWTestExecutor.java
@@ -32,8 +32,10 @@ public class BWTestExecutor
 	List<String> osgiCommands;
 	boolean skipInitMainProcessActivities;
 	boolean skipInitAllNonTestProcessActivities;
+	String customArgEngine;
 	
 
+	
 	List<String> mockActivity = new ArrayList<String>();
 	
 	
@@ -228,6 +230,15 @@ public class BWTestExecutor
 			boolean skipInitAllNonTestProcessActivities) {
 		this.skipInitAllNonTestProcessActivities = skipInitAllNonTestProcessActivities;
 	}
+	
+	public String getCustomArgEngine() {
+		return customArgEngine;
+	}
+
+	public void setCustomArgEngine(String customArgEngine) {
+		this.customArgEngine = customArgEngine;
+	}
+
 	
 	
 	


### PR DESCRIPTION
****What's this Pull request about?

Provided "customArgEngine" property to launch engine with custom properties. User need to provide property file path which has list of argument in the form of -Dkey=value.

****Which Issue(s) this Pull Request will fix?

#563 bwTest: support for passing vm arguments, similar to surefire:test argLine 

Yes

****How this pull request has been tested?

1. Provide the Absolute ,relative or URL based file path to "customArgEngine" property

****Screenshots (if appropriate)

Screenshot(s) of the change
![relativeFilePath](https://user-images.githubusercontent.com/31987978/109634282-1216c300-7b6f-11eb-92c8-96ced3282f80.jpg)
![Untitled](https://user-images.githubusercontent.com/31987978/109634312-193dd100-7b6f-11eb-9521-f3a4b2e64331.jpg)



****Any background context or comments you want to provide?

Short description of why these changes were made.



