### PR TITLE
Improved detection when application don't start properly

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineRunner.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setuplocal/EngineRunner.java
@@ -118,7 +118,8 @@ public class EngineRunner
 							latch.countDown();
 						}
 						//TIBCO-THOR-FRWK-300019: BW Application is impaired
-						if( line.contains( "TIBCO-THOR-FRWK-300019") && line.contains("impaired"))
+						if( ( line.contains( "TIBCO-THOR-FRWK-300019") && line.contains("impaired") ) ||
+								( line.contains( "TIBCO-THOR-FRWK-300008") && line.contains("Stopped BW Application") ) )
 						{
 							isImpaired.set(true);
 						}


### PR DESCRIPTION
****What's this Pull request about?

When application don't start but in logs appears 'Stopped BW Application' still waits 2 min until timeout.

****Does this pull request maintain backward compatibility?

Yes
