### PR TITLE
#561 shared module disappearing from studio after installing maven plugin 2.7.0 in BWCE 2.5.4

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
@@ -185,6 +185,10 @@ public class BWEARInstallerMojo extends AbstractMojo {
             }
             //TCI deployment
             if(projectType != null && projectType.equalsIgnoreCase(Constants.TCI)){
+            	if(!deployToAdmin) {
+	    			getLog().info("Deploy To Admin/TCI is set to False. Skipping EAR Deployment.");
+	    			return;
+	    		}
             	File [] files = BWFileUtils.getFilesForType(outputDirectory, ".ear");
  	    		if(files.length == 0) {
  	    			throw new Exception("EAR file not found for the Application");
@@ -206,7 +210,7 @@ public class BWEARInstallerMojo extends AbstractMojo {
 	    			return;
 	    		}
 	    		if(!deployToAdmin) {
-	    			getLog().info("Deploy To Admin is set to False. Skipping EAR Deployment.");
+	    			getLog().info("Deploy To Admin/TCI is set to False. Skipping EAR Deployment.");
 	    			return;
 	    		}
 	    		

--- a/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
+++ b/Source/bw6-studio-maven-plugin/bw6.studio.maven.plugin/src/com/tibco/bw/studio/maven/validation/BWMavenDependenciesBuilder.java
@@ -452,10 +452,10 @@ public class BWMavenDependenciesBuilder extends BWAbstractBuilder{
 					break;
 				}
 			}
-			if(remove){
+		/*	if(remove){  //It was unnecessarily removing the external dependencies for non-mavenised project as well
 				toRemove.add(record);
 			}
-
+*/
 		}
 
 		//Remove referenced projects from hostProject


### PR DESCRIPTION


****What's this Pull request about?

The issue is specific with the scenario where ESM is added using target platform and the dependencies section of module project. After adding it Studio will pull it into workspace but if the maven is installed on the studio then BW maven will remove it from the workspace.
In the Maven code, External added Shared module dependency has been removed from the workspace if it is not maven dependency. There is check for the Maven dependencies. If it is maven dependency then dependent project has not been removed but if it is ESM which is added using Target platform then it has been removed even though it is not maven project which is wrong.
Changes have been done to not remove ESM.

****Which Issue(s) this Pull Request will fix?

#561 shared module disappearing from studio after installing maven plugin 2.7.0 in BWCE 2.5.4




