### PR TITLE
NullPointer Exception while generating code coverage report for Subprocess having dependency on ESM 

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/coverage/ProcessCoverageParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/coverage/ProcessCoverageParser.java
@@ -1,32 +1,59 @@
 package com.tibco.bw.maven.plugin.test.coverage;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.project.DefaultDependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionException;
+import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
 
+import com.tibco.bw.maven.plugin.osgi.helpers.ManifestParser;
 import com.tibco.bw.maven.plugin.test.dto.CompleteReportDTO;
 import com.tibco.bw.maven.plugin.test.dto.ProcessCoverageDTO;
 import com.tibco.bw.maven.plugin.test.dto.TestSuiteResultDTO;
 import com.tibco.bw.maven.plugin.test.helpers.BWTestConfig;
 import com.tibco.bw.maven.plugin.utils.BWFileUtils;
+import com.tibco.bw.maven.plugin.utils.Constants;
+
+import org.eclipse.aether.graph.Dependency;
 
 public class ProcessCoverageParser
 {
 	
 	Map<String,ProcessCoverage> processMap = new HashMap<>();
+	
+	 @Component
+	  ProjectDependenciesResolver resolver;
+	 
+		HashMap<File,String> artifactFiles = new HashMap<File,String>();
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Map<String,ProcessCoverage> loadCoverage( CompleteReportDTO complete)	
 	{
 		List<MavenProject> projects = BWTestConfig.INSTANCE.getSession().getProjects();
+		resolver = BWTestConfig.INSTANCE.getResolver();
 		
 		
 		for( MavenProject project : projects )
@@ -34,8 +61,13 @@ public class ProcessCoverageParser
 			if( project.getPackaging().equals("bwmodule") )
 			{
 				loadProcesses( project);
+				loadProcessesFromESM(project);
+				
+				
 			}
 		}
+		
+		
 		
 		for( int count = 0 ; count < complete.getModuleResult().size() ; count++ )
 		{
@@ -45,17 +77,71 @@ public class ProcessCoverageParser
 			for( int i = 0; i < coverage.size() ; i++ )
 			{
 				ProcessCoverageDTO dto = (ProcessCoverageDTO) coverage.get( i );
-				ProcessCoverage pc = processMap.get( dto.getProcessName());
-				pc.setProcessExecuted(true);
-				pc.getActivitiesExec().addAll( dto.getActivityCoverage() );
-				pc.getTransitionExec().addAll( dto.getTransitionCoverage()  );
+				if(processMap.get( dto.getProcessName())!=null){
+					ProcessCoverage pc = processMap.get( dto.getProcessName());
+					pc.setProcessExecuted(true);
+					pc.getActivitiesExec().addAll( dto.getActivityCoverage() );
+					pc.getTransitionExec().addAll( dto.getTransitionCoverage()  );
+				}
 			}
 		}	
 		
 		return processMap;
 	}
 	
-	
+	private void loadProcessesFromESM(MavenProject project) {
+		 DependencyResolutionResult resolutionResult = getDependencies(project,BWTestConfig.INSTANCE.getSession());
+		 if (resolutionResult != null) {
+	        	for(Dependency dependency : resolutionResult.getDependencies()) {
+	    			if(!dependency.getArtifact().getVersion().equals("0.0.0")) {
+	            		artifactFiles.put(dependency.getArtifact().getFile(),dependency.getArtifact().getArtifactId());
+	    			}
+	        	}
+	        }
+			for(File file : artifactFiles.keySet()) {
+				if( file.getName().indexOf("com.tibco.bw.palette.shared") != -1 || file.getName().indexOf("com.tibco.xml.cxf.common") != -1 || file.getName().indexOf("tempbw") != -1){
+					continue;
+				}
+				boolean isSharedModule = false;
+				Manifest mf = ManifestParser.parseManifestFromJAR( file);
+				if(mf == null){
+					try {
+						throw new Exception("Failed to get Manifest for - "+ file.getName() +". Please verify if jar file is valid, the MANIFEST.MF should be first or second entry in the jar file. Use Command - jar tf <Jar_File_Path> to verify.");
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+				}
+				for( Object str : mf.getMainAttributes().keySet())
+				{
+					if( Constants.TIBCO_SHARED_MODULE.equals(str.toString() ))
+					{
+						isSharedModule = true;
+						break;
+					}
+				}
+				if(isSharedModule){
+					try {
+						parseESM(file, artifactFiles.get(file));
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		
+	}
+
+	private DependencyResolutionResult getDependencies(MavenProject project, MavenSession session) {
+		DependencyResolutionResult resolutionResult = null;
+
+		try {
+			DefaultDependencyResolutionRequest resolution = new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
+			resolutionResult = resolver.resolve(resolution);
+		} catch (DependencyResolutionException e) {
+			e.printStackTrace();
+			resolutionResult = e.getResult();
+		}
+		return resolutionResult;
+	}
 	private void loadProcesses( MavenProject project )
 	{
 		List<File> files =  getProcessFiles(project);
@@ -92,10 +178,44 @@ public class ProcessCoverageParser
 			coverage.setModuleName(module);
 			processMap.put( coverage.getProcessName(),  coverage);	
 		}
+	}
+	
+	private void parseESM( File processFile , String module ) throws Exception
+	{
+		String xml=null;
+		String zipFileName = processFile.getAbsolutePath();
 		
-		
-		
-		
+
+		try (FileInputStream fis = new FileInputStream(zipFileName);
+				BufferedInputStream bis = new BufferedInputStream(fis);
+				ZipInputStream stream = new ZipInputStream(bis)) {
+
+			ZipEntry entry;
+			ZipFile zf = new ZipFile(zipFileName);
+			while ((entry = stream.getNextEntry()) != null) {
+				String name = entry.getName();
+				if (name.endsWith(".bwp")) {
+					InputStream in = zf.getInputStream(entry);
+					xml = IOUtils.toString(in, StandardCharsets.UTF_8.name());
+					if( null != xml ){
+						ProcessParser parser = new ProcessParser();
+						XMLReader reader  = XMLReaderFactory.createXMLReader();			
+						reader.setContentHandler(parser );
+						reader.parse(new InputSource(new StringReader( xml )));
+						ProcessCoverage coverage = parser.getCoverage();
+						if( coverage.isSubProcess()) 
+						{
+							coverage.setModuleName(module);
+							processMap.put( coverage.getProcessName(),  coverage);	
+						}
+					}
+				}
+			}
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 	
 	private List<File> getProcessFiles( MavenProject project )
@@ -104,8 +224,6 @@ public class ProcessCoverageParser
 		List<File> files = BWFileUtils.getEntitiesfromLocation( baseDir.toString() , "bwp");
 		
 		return files;
-		
-		
 		
 	}
 	

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/coverage/ProcessCoverageParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/coverage/ProcessCoverageParser.java
@@ -1,59 +1,32 @@
 package com.tibco.bw.maven.plugin.test.coverage;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.jar.Manifest;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.project.DefaultDependencyResolutionRequest;
-import org.apache.maven.project.DependencyResolutionException;
-import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectDependenciesResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
 
-import com.tibco.bw.maven.plugin.osgi.helpers.ManifestParser;
 import com.tibco.bw.maven.plugin.test.dto.CompleteReportDTO;
 import com.tibco.bw.maven.plugin.test.dto.ProcessCoverageDTO;
 import com.tibco.bw.maven.plugin.test.dto.TestSuiteResultDTO;
 import com.tibco.bw.maven.plugin.test.helpers.BWTestConfig;
 import com.tibco.bw.maven.plugin.utils.BWFileUtils;
-import com.tibco.bw.maven.plugin.utils.Constants;
-
-import org.eclipse.aether.graph.Dependency;
 
 public class ProcessCoverageParser
 {
 	
 	Map<String,ProcessCoverage> processMap = new HashMap<>();
-	
-	 @Component
-	  ProjectDependenciesResolver resolver;
-	 
-		HashMap<File,String> artifactFiles = new HashMap<File,String>();
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Map<String,ProcessCoverage> loadCoverage( CompleteReportDTO complete)	
 	{
 		List<MavenProject> projects = BWTestConfig.INSTANCE.getSession().getProjects();
-		resolver = BWTestConfig.INSTANCE.getResolver();
 		
 		
 		for( MavenProject project : projects )
@@ -61,13 +34,8 @@ public class ProcessCoverageParser
 			if( project.getPackaging().equals("bwmodule") )
 			{
 				loadProcesses( project);
-				loadProcessesFromESM(project);
-				
-				
 			}
 		}
-		
-		
 		
 		for( int count = 0 ; count < complete.getModuleResult().size() ; count++ )
 		{
@@ -77,71 +45,17 @@ public class ProcessCoverageParser
 			for( int i = 0; i < coverage.size() ; i++ )
 			{
 				ProcessCoverageDTO dto = (ProcessCoverageDTO) coverage.get( i );
-				if(processMap.get( dto.getProcessName())!=null){
-					ProcessCoverage pc = processMap.get( dto.getProcessName());
-					pc.setProcessExecuted(true);
-					pc.getActivitiesExec().addAll( dto.getActivityCoverage() );
-					pc.getTransitionExec().addAll( dto.getTransitionCoverage()  );
-				}
+				ProcessCoverage pc = processMap.get( dto.getProcessName());
+				pc.setProcessExecuted(true);
+				pc.getActivitiesExec().addAll( dto.getActivityCoverage() );
+				pc.getTransitionExec().addAll( dto.getTransitionCoverage()  );
 			}
 		}	
 		
 		return processMap;
 	}
 	
-	private void loadProcessesFromESM(MavenProject project) {
-		 DependencyResolutionResult resolutionResult = getDependencies(project,BWTestConfig.INSTANCE.getSession());
-		 if (resolutionResult != null) {
-	        	for(Dependency dependency : resolutionResult.getDependencies()) {
-	    			if(!dependency.getArtifact().getVersion().equals("0.0.0")) {
-	            		artifactFiles.put(dependency.getArtifact().getFile(),dependency.getArtifact().getArtifactId());
-	    			}
-	        	}
-	        }
-			for(File file : artifactFiles.keySet()) {
-				if( file.getName().indexOf("com.tibco.bw.palette.shared") != -1 || file.getName().indexOf("com.tibco.xml.cxf.common") != -1 || file.getName().indexOf("tempbw") != -1){
-					continue;
-				}
-				boolean isSharedModule = false;
-				Manifest mf = ManifestParser.parseManifestFromJAR( file);
-				if(mf == null){
-					try {
-						throw new Exception("Failed to get Manifest for - "+ file.getName() +". Please verify if jar file is valid, the MANIFEST.MF should be first or second entry in the jar file. Use Command - jar tf <Jar_File_Path> to verify.");
-					} catch (Exception e) {
-						e.printStackTrace();
-					}
-				}
-				for( Object str : mf.getMainAttributes().keySet())
-				{
-					if( Constants.TIBCO_SHARED_MODULE.equals(str.toString() ))
-					{
-						isSharedModule = true;
-						break;
-					}
-				}
-				if(isSharedModule){
-					try {
-						parseESM(file, artifactFiles.get(file));
-					} catch (Exception e) {
-						e.printStackTrace();
-					}
-				}
-			}
-		
-	}
-
-	private DependencyResolutionResult getDependencies(MavenProject project, MavenSession session) {
-		DependencyResolutionResult resolutionResult = null;
-
-		try {
-			DefaultDependencyResolutionRequest resolution = new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
-			resolutionResult = resolver.resolve(resolution);
-		} catch (DependencyResolutionException e) {
-			e.printStackTrace();
-			resolutionResult = e.getResult();
-		}
-		return resolutionResult;
-	}
+	
 	private void loadProcesses( MavenProject project )
 	{
 		List<File> files =  getProcessFiles(project);
@@ -178,44 +92,10 @@ public class ProcessCoverageParser
 			coverage.setModuleName(module);
 			processMap.put( coverage.getProcessName(),  coverage);	
 		}
-	}
-	
-	private void parseESM( File processFile , String module ) throws Exception
-	{
-		String xml=null;
-		String zipFileName = processFile.getAbsolutePath();
 		
-
-		try (FileInputStream fis = new FileInputStream(zipFileName);
-				BufferedInputStream bis = new BufferedInputStream(fis);
-				ZipInputStream stream = new ZipInputStream(bis)) {
-
-			ZipEntry entry;
-			ZipFile zf = new ZipFile(zipFileName);
-			while ((entry = stream.getNextEntry()) != null) {
-				String name = entry.getName();
-				if (name.endsWith(".bwp")) {
-					InputStream in = zf.getInputStream(entry);
-					xml = IOUtils.toString(in, StandardCharsets.UTF_8.name());
-					if( null != xml ){
-						ProcessParser parser = new ProcessParser();
-						XMLReader reader  = XMLReaderFactory.createXMLReader();			
-						reader.setContentHandler(parser );
-						reader.parse(new InputSource(new StringReader( xml )));
-						ProcessCoverage coverage = parser.getCoverage();
-						if( coverage.isSubProcess()) 
-						{
-							coverage.setModuleName(module);
-							processMap.put( coverage.getProcessName(),  coverage);	
-						}
-					}
-				}
-			}
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		
+		
+		
 	}
 	
 	private List<File> getProcessFiles( MavenProject project )
@@ -224,6 +104,8 @@ public class ProcessCoverageParser
 		List<File> files = BWFileUtils.getEntitiesfromLocation( baseDir.toString() , "bwp");
 		
 		return files;
+		
+		
 		
 	}
 	

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/BWTestConfig.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/BWTestConfig.java
@@ -9,9 +9,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectDependenciesResolver;
 
 public class BWTestConfig 
 {
@@ -37,8 +35,6 @@ public class BWTestConfig
 	private MavenSession session;
 	
 	private MavenProject project;
-	
-	ProjectDependenciesResolver resolver;
 	
 	private Log logger;
 	
@@ -208,14 +204,6 @@ public class BWTestConfig
 
 	public void setUserTestSuiteNames(Map<String, Boolean> userTestSuiteNames) {
 		this.userTestSuiteNames = userTestSuiteNames;
-	}
-
-	public ProjectDependenciesResolver getResolver() {
-		return resolver;
-	}
-
-	public void setResolver(ProjectDependenciesResolver resolver) {
-		this.resolver = resolver;
 	}
 	
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/BWTestConfig.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/BWTestConfig.java
@@ -9,7 +9,9 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
 
 public class BWTestConfig 
 {
@@ -35,6 +37,8 @@ public class BWTestConfig
 	private MavenSession session;
 	
 	private MavenProject project;
+	
+	ProjectDependenciesResolver resolver;
 	
 	private Log logger;
 	
@@ -204,6 +208,14 @@ public class BWTestConfig
 
 	public void setUserTestSuiteNames(Map<String, Boolean> userTestSuiteNames) {
 		this.userTestSuiteNames = userTestSuiteNames;
+	}
+
+	public ProjectDependenciesResolver getResolver() {
+		return resolver;
+	}
+
+	public void setResolver(ProjectDependenciesResolver resolver) {
+		this.resolver = resolver;
 	}
 	
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestsReport.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestsReport.java
@@ -18,7 +18,6 @@ import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.ProjectDependenciesResolver;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 
@@ -34,14 +33,11 @@ public class BWTestsReport extends AbstractMavenReport
 	@Parameter(defaultValue="${session}", readonly=true)
 	  private MavenSession session;
 
-	  @Parameter( property = "showFailureDetails" , defaultValue = "true" )
+	  @Parameter( property = "showFailureDetails" , defaultValue = "false" )
 	    private boolean showFailureDetails;
 	  
 	  @Parameter( property = "testSuiteName" , defaultValue = "" )
 	    private String testSuiteName;
-	  
-	  @Component
-	    ProjectDependenciesResolver resolver;
 
 
 	@Override
@@ -118,7 +114,6 @@ public class BWTestsReport extends AbstractMavenReport
 			BWTestConfig.INSTANCE.init(  tibcoHome , bwHome , session, getProject() , logger );
 			TestFileParser.INSTANCE.setshowFailureDetails(showFailureDetails);
 			BWTestConfig.INSTANCE.setTestSuiteName(testSuiteName);
-			BWTestConfig.INSTANCE.setResolver(resolver);
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestsReport.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/report/BWTestsReport.java
@@ -18,6 +18,7 @@ import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.ProjectDependenciesResolver;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 
@@ -33,11 +34,14 @@ public class BWTestsReport extends AbstractMavenReport
 	@Parameter(defaultValue="${session}", readonly=true)
 	  private MavenSession session;
 
-	  @Parameter( property = "showFailureDetails" , defaultValue = "false" )
+	  @Parameter( property = "showFailureDetails" , defaultValue = "true" )
 	    private boolean showFailureDetails;
 	  
 	  @Parameter( property = "testSuiteName" , defaultValue = "" )
 	    private String testSuiteName;
+	  
+	  @Component
+	    ProjectDependenciesResolver resolver;
 
 
 	@Override
@@ -114,6 +118,7 @@ public class BWTestsReport extends AbstractMavenReport
 			BWTestConfig.INSTANCE.init(  tibcoHome , bwHome , session, getProject() , logger );
 			TestFileParser.INSTANCE.setshowFailureDetails(showFailureDetails);
 			BWTestConfig.INSTANCE.setTestSuiteName(testSuiteName);
+			BWTestConfig.INSTANCE.setResolver(resolver);
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();


### PR DESCRIPTION
****What's this Pull request about?

NullPointer Exception while generating code coverage report for Subprocess having dependency on ESM 

****Which Issue(s) this Pull Request will fix?

https://github.com/TIBCOSoftware/bw6-plugin-maven/issues/597

****Does this pull request maintain backward compatibility?
yes

****How this pull request has been tested?

In Bw Maven Plugin code the above mentioned use was not handled. Now the changes have done which will cover the subprocesses from the ESM as well and will provide the code coverage data in Code Coverage report as well.

Testing Done:
1. Project attached with Jira has been tested. Attached the code coverage report
2. Report has been generated for Project which has more than 1 ESM. Please find attached project and reports.

****Screenshots (if appropriate)

Screenshot(s) of the change

****Any background context or comments you want to provide?

Short description of why these changes were made.



