### PR TITLE
AMBW-43583 Assertion: Activity Output is empty if TestInput is of Integer primitive type

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
@@ -377,6 +377,9 @@ public class TestFileParser {
 				String elementNameString = StringUtils.substringBefore(goldValueWithElement, "=");
 				String[] elementNameArray = StringUtils.split(elementNameString, "/");
 				String elementName = elementNameArray[elementNameArray.length-1];
+				if(elementName.contains(")")){
+					elementName = StringUtils.removeEnd(elementName, ")");
+				}
 				String startElementTag = "<".concat(elementName).concat(">");
 				String endElementTag = "</".concat(elementName).concat(">");
 	


### PR DESCRIPTION
Activity Output is empty if TestInput is of Integer primitive type