### PR TITLE
AMBW-45306 Support for assertion of activities within a group

### DIFF
--- a/Source/bw6-maven-plugin/pom.xml
+++ b/Source/bw6-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.tibco.plugins</groupId>
 	<artifactId>bw6-maven-plugin</artifactId>
-	<version>2.9.1</version>
+	<version>2.9.2</version>
 	<packaging>maven-plugin</packaging>
 	<name>Plugin Code for Apache Maven and TIBCO BusinessWorks™</name>
 	<description>Plugin Code for Apache Maven and TIBCO BusinessWorks™.

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/helpers/TestFileParser.java
@@ -124,6 +124,7 @@ public class TestFileParser {
 
 									String location = cEl.getAttributes().getNamedItem("Id").getNodeValue();
 									String activityName = cEl.getAttributes().getNamedItem("Name").getNodeValue();
+									ast.setActivityId(activityName);
 									ast.setLocation(location);
 
 									NodeList gChildNodes = cEl.getChildNodes();


### PR DESCRIPTION
Issue Description - 
When we apply Assertion to any activity in the group, the assertion fails with this exception - "Index 1 out of bounds for length 1 error".

Fix Details - 
The activity in the group on which assertion was applied, passed the assertion for all the n iterations, but while framing the Result of the Assertion, it was giving the above mentioned error. There were n results for n iterations where the assertion was evaluated. For the n iterations, the Assertion (Gold Value) used was only one. What was happening in the code, after one result was logged for an assertion, that assertion was surpassed and for the next result, next assertion was expected. 
This cannot happen if the activity is in group. When an activity is in group, it will be evaluated n times for the same Assertion. So while framing the result, n results for that activity must be made over that single assertion only. 
NOTE : The fix has been made considering 2 assumptions -
1. No two activities in a process can have same name (be inside or outside the group).
2. For n different iterations of the group, one cannot change the assertion on a particular activity. However the Assertion result may change depending on the input to that activity and its evaluated output.

Testing Done - 
1. Tested Mapper Activity in For Each Group for 3 iterations. It worked fine. Result was - Tests run : 1    Success : 3  Failure : 0  Errors : 0
2. Tested Render Data Activity in Repeat Group for 3 iterations. This also worked fine.  Result was - Tests run : 1    Success : 3  Failure : 0  Errors : 0

3. Tested with 2 assertions, one on Render Data which is inside group (3 iterations), and the other on Mapper activity which is outside the group. Worked fine. Tests run : 1    Success : 4 Failure : 0 Errors : 0

4. Tested 2 assertions, both inside the group (3 iterations), one on Render Data and the other on Mapper activity. Tests run : 1    Success : 6 Failure : 0 Errors : 0
5. Tested the assertion with Gold File also.
6. When there were 2 activities in the process, tried adding assertion to the 2nd activity first & then to the first activity.
7. bwtest results incorrect when we have a failure case of assertion.

Testing Scope - 
SubProcess
Service
Other Activities and Groups

Affected RU - 
com.tibco.bw.thor.management.feature
"D:\maven_master\Maven2.9.2\bw6-plugin-maven\Source\bw6-maven-plugin\src\main\java\com\tibco\bw\maven\plugin\test\helpers\TestFileParser.java"

Local Build -
Successful