### PR TITLE
AMBW-46471 [Maven]  maven install goal throws error  missing values r…

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARInstallerMojo.java
@@ -289,13 +289,14 @@ public class BWEARInstallerMojo extends AbstractMojo {
             }else {
             	//enterprise deployment
 	    		boolean configFileExists = deploymentConfigExists();
-	    		if(configFileExists) {
-	    			loadFromDeploymentProperties();
-	    		}
-	    		if(!validateFields()) {
-	    			getLog().error("Validation failed. Skipping EAR Deployment.");
-	    			return;
-	    		}
+				if (configFileExists) {
+					loadFromDeploymentProperties();
+
+					if (!validateFields()) {
+						getLog().error("Validation failed. Skipping EAR Deployment.");
+						return;
+					}
+				}
 	    		if(!deployToAdmin) {
 	    			getLog().info("Deploy To Admin/TCI is set to False. Skipping EAR Deployment.");
 	    			return;


### PR DESCRIPTION
What's this Pull request about?

Changes are done to do validation when the deploy is selected for Appspace.  For None option, validate fields is skipped.

Maintains backward compatibility as the validation for fields are done for deploy option AppSpace

The changes are tested for deploy option None and the error message that is seen earlier due to field validations (not applicable for None option), were not seen anymore.

Mention the test scenarios.

1. Create a sample project
2. add a timer activity and a test file
3. Generate POM, during POM creation select deploy option as None
4. select the parent project and trigger manven -> install option.
5. Observe the ERROR messages are not seen.