### PR TITLE
AMBW-47325 [[Regression][Maven] Maven Goal parameters shows extra log…

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/log/filter/SystemStreamLogWithFilter.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/log/filter/SystemStreamLogWithFilter.java
@@ -1,0 +1,209 @@
+package com.tibco.bw.maven.plugin.log.filter;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * "standard" apache output and error output stream logger with filter to remove messages from non BW plugins.
+ *
+ * @author lshivara
+ */
+public class SystemStreamLogWithFilter  implements Log
+{
+	
+	private String[] exclusions = { "org.apache.maven", "org.eclipse.aether", "org.eclipse.m2e", "org.eclipse.jgit",
+			"excludes []", "includes []", "-application", "-ws", "win32", "com.tibco.bw.core.design.project.BwDesignApplication", "/eclipse", 
+			"\\eclipse", "\\src\\test\\resources", "\\src\\main\\resources", "/src/test/resources", "/src/main/resources"};
+	
+	private String previousLogLine = null;
+	
+    /**
+     * @see org.apache.maven.plugin.logging.Log#debug(java.lang.CharSequence)
+     */
+    public void debug(CharSequence content)
+    {
+        print("debug", content);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#debug(java.lang.CharSequence, java.lang.Throwable)
+     */
+    public void debug(CharSequence content, Throwable error)
+    {
+        print("debug", content, error);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#debug(java.lang.Throwable)
+     */
+    public void debug(Throwable error)
+    {
+        print("debug", error);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#info(java.lang.CharSequence)
+     */
+    public void info(CharSequence content)
+    {
+        print("info", content);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#info(java.lang.CharSequence, java.lang.Throwable)
+     */
+    public void info(CharSequence content, Throwable error)
+    {
+        print("info", content, error);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#info(java.lang.Throwable)
+     */
+    public void info(Throwable error)
+    {
+        print("info", error);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#warn(java.lang.CharSequence)
+     */
+    public void warn(CharSequence content)
+    {
+        print("warn", content);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#warn(java.lang.CharSequence, java.lang.Throwable)
+     */
+    public void warn(CharSequence content, Throwable error)
+    {
+        print("warn", content, error);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#warn(java.lang.Throwable)
+     */
+    public void warn(Throwable error)
+    {
+        print("warn", error);
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#error(java.lang.CharSequence)
+     */
+    public void error(CharSequence content)
+    {
+        System.err.println("[error] " + content.toString());
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#error(java.lang.CharSequence, java.lang.Throwable)
+     */
+    public void error(CharSequence content, Throwable error)
+    {
+        StringWriter sWriter = new StringWriter();
+        PrintWriter pWriter = new PrintWriter(sWriter);
+
+        error.printStackTrace(pWriter);
+
+        System.err.println("[error] " + content.toString() + "\n\n" + sWriter.toString());
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#error(java.lang.Throwable)
+     */
+    public void error(Throwable error)
+    {
+        StringWriter sWriter = new StringWriter();
+        PrintWriter pWriter = new PrintWriter(sWriter);
+
+        error.printStackTrace(pWriter);
+
+        System.err.println("[error] " + sWriter.toString());
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#isDebugEnabled()
+     */
+    public boolean isDebugEnabled()
+    {
+        // TODO Not sure how best to set these for this implementation...
+        return false;
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#isInfoEnabled()
+     */
+    public boolean isInfoEnabled()
+    {
+        return true;
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#isWarnEnabled()
+     */
+    public boolean isWarnEnabled()
+    {
+        return true;
+    }
+
+    /**
+     * @see org.apache.maven.plugin.logging.Log#isErrorEnabled()
+     */
+    public boolean isErrorEnabled()
+    {
+        return true;
+    }
+    
+    private void print(String prefix, CharSequence content)
+    {
+    	boolean nonBWLog = false;
+    	String contentString = content.toString();
+    	for (String exclude: exclusions) {
+    		nonBWLog = contentString.contains(exclude) ? true : false;
+    		if (nonBWLog) {
+    			break;
+    		}
+    	}
+        if (!nonBWLog) {
+        	printLog(prefix, contentString);
+        }
+    }
+
+    private void printLog(String prefix, String content)
+    {
+    	String logPrintLine =  content.toString();
+    	//log formatting - Remove successive blank lines in log
+		if (previousLogLine == null || previousLogLine.isEmpty()) {
+			if (!logPrintLine.isEmpty()) {
+				System.out.println("[" + prefix + "] " + logPrintLine);
+			}
+		}else {
+			System.out.println("[" + prefix + "] " + logPrintLine);
+		}
+        previousLogLine = logPrintLine;
+    }
+    
+
+    private void print(String prefix, Throwable error)
+    {
+        StringWriter sWriter = new StringWriter();
+        PrintWriter pWriter = new PrintWriter(sWriter);
+
+        error.printStackTrace(pWriter);
+        printLog(prefix, sWriter.toString());
+    }
+
+    private void print(String prefix, CharSequence content, Throwable error)
+    {
+        StringWriter sWriter = new StringWriter();
+        PrintWriter pWriter = new PrintWriter(sWriter);
+
+        error.printStackTrace(pWriter);
+        printLog(prefix, content.toString() + "\n" + sWriter.toString());
+    }
+
+}

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/process/BWDesignUtilityExecutorMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/process/BWDesignUtilityExecutorMojo.java
@@ -1,7 +1,11 @@
 package com.tibco.bw.maven.plugin.process;
 
-import com.tibco.bw.maven.plugin.utils.BWProjectUtils;
-import com.tibco.bw.maven.plugin.utils.Constants;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -12,12 +16,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
+import com.tibco.bw.maven.plugin.log.filter.SystemStreamLogWithFilter;
+import com.tibco.bw.maven.plugin.utils.BWProjectUtils;
+import com.tibco.bw.maven.plugin.utils.Constants;
 
 @Mojo(name = "bwdesignUtility")
 public class BWDesignUtilityExecutorMojo extends AbstractMojo{
@@ -125,7 +126,7 @@ public class BWDesignUtilityExecutorMojo extends AbstractMojo{
 	        logger.info("--------------------- Executing BWDesign Utility Command : "+ commandName +" -----------------------");
 			logger.debug("Launching bwdesign utility with params: " + params);
 
-			printProcessOutput(process);
+			printProcessOutput(process, params);
 
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -156,7 +157,7 @@ public class BWDesignUtilityExecutorMojo extends AbstractMojo{
 	        logger.info("---------------------Generating Process diagram-----------------------");
 			logger.debug("Launching bwdesign utility with params: " + params);
 
-			printProcessOutput(process);
+			printProcessOutput(process, params);
 
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -186,7 +187,7 @@ public class BWDesignUtilityExecutorMojo extends AbstractMojo{
 	        logger.info("---------------------Generating Manifest JSON-----------------------");
 			logger.debug("Launching bwdesign utility with params: " + params);
 
-			printProcessOutput(process);
+			printProcessOutput(process, params);
 
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -226,8 +227,7 @@ public class BWDesignUtilityExecutorMojo extends AbstractMojo{
 			logger.info("---------------------Validating BW Project-----------------------");
 			logger.debug("Launching bwdesign utility with params: " + params);
 			final Process process = builder.start();
-
-			printProcessOutput(process);
+			printProcessOutput(process, params);
 
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -257,7 +257,7 @@ public class BWDesignUtilityExecutorMojo extends AbstractMojo{
 			logger.info("-----------------Import Projects to Workspaces-------------------");
 			logger.debug("Launching bwdesign utility with params: " + params);
 
-			printProcessOutput(process);
+			printProcessOutput(process, params);
 
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -275,17 +275,25 @@ public class BWDesignUtilityExecutorMojo extends AbstractMojo{
 		return String.join(",", projectList);
 	}
 
-	private void printProcessOutput(Process process) throws IOException {
-		BufferedReader reader= null;
+	private void printProcessOutput(Process process, List<String> params) throws IOException {
+		BufferedReader reader = null;
 		String line = null;
-
 		reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 		while ((line = reader.readLine()) != null) {
-			//System.err.println(line);
-			logger.info(line);
+			if (!params.contains(line)) {
+				logger.info(line);
+			}
 		}
-
 		reader.close();
+	}
+	
+	
+	@Override
+	public Log getLog() {
+		if (logger == null) {
+			logger = new SystemStreamLogWithFilter();
+		}
+		return logger;
 	}
 }
 


### PR DESCRIPTION
****What's this Pull request about?
Executiong of bwdesign with import, validate, gen_diagrams, generate_maifest_json commands were 
generating extra logs compared to earlier releases.
The logs were generated by different eclipse internal plugins, which are not required in console.
The requirement is to maintain logs as in 6.8 release and remove or filterout the unwanted logs from console.


****Which Issue(s) this Pull Request will fix?
This will remove excess logs being introdueced for bwdesign commands import, validate, gen_diagrams, generate_maifest_json commands.
Maintain the logs output for the commands mentioned above to 6.80 release.

****Does this pull request maintain backward compatibility?
Yes, this is to maintain the log generation to 6.80 release. 

****How this pull request has been tested?
The logs are generated by various external plugins.  A system logger is added, which is used in the mojo class.
The logger will filter out logs generated by external plugins and also many of the parameters passed to the 
bwdesing commands were also printed to console, cluttering the console.  These are also filtered out.
Followed the test instructions given in the JIRA ticket.
Executed the commands mentioned in the ticket and compared the log generated to reference 6.80 logs.  