### PR TITLE
BWCE-8847 [Support][Maven] Unit Testing: Wrong order in test input vs…

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/rest/BWTestRunner.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/rest/BWTestRunner.java
@@ -675,8 +675,8 @@ public class BWTestRunner
         Diff myDiff;
 		try {
 			myDiff = DiffBuilder
-			  .compare(inputValue)
-			  .withTest(goldInput)
+			  .compare(goldInput)
+			  .withTest(inputValue)
 			  .ignoreComments()
 			  .ignoreWhitespace()
 			  .withComparisonController(ComparisonControllers.StopWhenDifferent)


### PR DESCRIPTION
****What's this Pull request about?
During unit test the gold input should be the control input and the input given in input property page should the test input.
In current implmentation, the input property page values are given for comparison as control input.
This is resulting in message showing values in error message in reverse. 


****Which Issue(s) this Pull Request will fix?
This will fix the order in test input vs test expected. On comparison failure, it will show the gold input value is compared to test input.

****Does this pull request maintain backward compatibility?
Yes, comparison is not impacted.  Comparison of values given in gold input vs input given in input property page is done. 

****How this pull request has been tested?
Followed the test instructions given in the JIRA ticket.

****Any background context or comments you want to provide?
The ticket is reported by support as per customer reported issue.



