### PR TITLE
BWCE-8783 Support [MACIF SAM] : Customer facing issue with changing the snapsho…

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARPackagerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/application/BWEARPackagerMojo.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+import java.util.jar.Attributes.Name;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -104,9 +105,8 @@ public class BWEARPackagerMojo extends AbstractMojo {
     	    archiveConfiguration = new MavenArchiveConfiguration();
     	    moduleVersionMap = new HashMap<String, String>();
             manifest = ManifestParser.parseManifest(projectBasedir);
-            ManifestWriter.updateManifestVersion(project, manifest, Constants.TIMESTAMP);
+            ManifestWriter.udpateManifestAttributes(project, manifest, Constants.TIMESTAMP);
             getLog().info("Updated the Manifest version ");
-            updateManifestVersion();
     	    getLog().info("Adding Modules to the EAR file");
     		addModules();
     		getLog().info("Adding EAR Information to the EAR File");
@@ -627,14 +627,5 @@ public class BWEARPackagerMojo extends AbstractMojo {
 			file.delete();
 		}
 		getLog().debug("cleaned up the temporary files.");
-    }
-    /**
-     *  Updated the Application manifest just like the module one
-     */
-    private void updateManifestVersion() {
-    	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-    	String qualifierVersion = VersionParser.getcalculatedOSGiVersion(version, Constants.TIMESTAMP);
-    	getLog().info("The OSGi verion is " + qualifierVersion + " for Maven version of " + version);
-    	manifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, qualifierVersion);
     }
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/module/BWModulePackageMojo.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.Manifest;
+import java.util.jar.Attributes.Name;
 
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
@@ -99,12 +100,12 @@ public class BWModulePackageMojo extends AbstractMojo {
             	throw new Exception("Failed to parse MANIFEST.MF for project -> "+ projectBasedir);
             }
             getLog().info("Updated the Manifest version ");
-            
-            ManifestWriter.updateManifestVersion(project, manifest, qualifierReplacement);
-            updateManifestVersion();
+            ManifestWriter.udpateManifestAttributes(project, manifest, qualifierReplacement);
             
             getLog().info("Removing the externals entries if any. ");
             removeExternals();
+            
+            ManifestParser.updateWriteManifest(projectBasedir, manifest);
 
             File pluginFile = getPluginJAR();
             getLog().info("Created Plugin JAR with name " + pluginFile.toString());
@@ -267,7 +268,7 @@ public class BWModulePackageMojo extends AbstractMojo {
 	}
 
 	private File getPluginJAR() {
-		String qualifierVersion = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
+		String qualifierVersion = manifest.getMainAttributes().getValue(Constants.ARCHIVE_FILE_VERSION);
 		if(qualifierVersion != null && qualifierVersion.endsWith(".")) {
 			qualifierVersion = qualifierVersion.substring(0, qualifierVersion.lastIndexOf("."));
 		}
@@ -353,12 +354,6 @@ public class BWModulePackageMojo extends AbstractMojo {
     	else {
     		return false;
     	}
-    }
-    private void updateManifestVersion() {
-    	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-    	String qualifierVersion = VersionParser.getcalculatedOSGiVersion(version, qualifierReplacement);
-    	getLog().info("The OSGi verion is " + qualifierVersion + " for Maven version of " + version);
-    	manifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, qualifierVersion);
     }
 
     private void removeExternals() {

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/osgi/helpers/ManifestWriter.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/osgi/helpers/ManifestWriter.java
@@ -32,31 +32,38 @@ public class ManifestWriter {
     }
     
     
-    public static void updateManifestVersion(MavenProject project , Manifest mf, String qualifierReplacement)
+    public static void udpateManifestAttributes(MavenProject project , Manifest mf, String qualifierReplacement)
     {
         Attributes attributes = mf.getMainAttributes();
         
-        String projectVersion = project.getVersion();
-        if( projectVersion.indexOf("-SNAPSHOT") != -1 )
+        String bundleVersion = project.getVersion();
+        String archiveVersion = bundleVersion;
+        if( bundleVersion.indexOf("-SNAPSHOT") != -1 )
         {
-        	projectVersion = projectVersion.replace("-SNAPSHOT", ".qualifier");
-        	projectVersion = getManifestVersion(mf, projectVersion, qualifierReplacement);
+        	archiveVersion = bundleVersion.replace("-SNAPSHOT", ".qualifier");
+        	bundleVersion = archiveVersion;
         }
         
-    	attributes.put(Name.MANIFEST_VERSION, projectVersion);
-        attributes.putValue(Constants.BUNDLE_VERSION, projectVersion );
-
+        archiveVersion = getManifestVersion(mf, archiveVersion, qualifierReplacement);
+    	attributes.putValue(Constants.BUNDLE_VERSION, bundleVersion);
+    	attributes.putValue(Constants.ARCHIVE_FILE_VERSION, archiveVersion);
         //Updating provide capability for Shared Modules
         if(BWProjectUtils.getModuleType(mf) == MODULE.SHAREDMODULE){
-        	String updatedProvide = ManifestParser.getUpdatedProvideCapabilities(mf, projectVersion);
+        	String updatedProvide = ManifestParser.getUpdatedProvideCapabilities(mf, bundleVersion);
         	attributes.putValue(Constants.BUNDLE_PROVIDE_CAPABILITY, updatedProvide);
         }
-
+        
+        if(BWProjectUtils.getModuleType(mf) == MODULE.APPLICATION || BWProjectUtils.getModuleType(mf) == MODULE.APPMODULE){
+        	String reqCapbilityValue = attributes.getValue(Constants.BUNDLE_REQUIRE_CAPABILITY);
+        	if (reqCapbilityValue != null) {
+        		String requiredCapability = ManifestParser.getRequiredCapabilities(reqCapbilityValue, bundleVersion);
+        		attributes.putValue(Constants.BUNDLE_REQUIRE_CAPABILITY, requiredCapability);
+        	}
+        }
     }
     
     private static String getManifestVersion( Manifest manifest , String version, String qualifierReplacement) 
     {    	
     	return VersionParser.getcalculatedOSGiVersion(version, qualifierReplacement);
     }
-
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setupenterprise/BWEARTestPackagerMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setupenterprise/BWEARTestPackagerMojo.java
@@ -103,9 +103,8 @@ public class BWEARTestPackagerMojo extends AbstractMojo {
     	    archiveConfiguration = new MavenArchiveConfiguration();
     	    moduleVersionMap = new HashMap<String, String>();
             manifest = ManifestParser.parseManifest(projectBasedir);
-            ManifestWriter.updateManifestVersion(project, manifest, Constants.TIMESTAMP);
+            ManifestWriter.udpateManifestAttributes(project, manifest, Constants.TIMESTAMP);
             getLog().info("Updated the Manifest version ");
-            updateManifestVersion();
     	    getLog().info("Adding Modules to the EAR file");
     		addModules();
     		getLog().info("Adding EAR Information to the EAR File");
@@ -436,24 +435,6 @@ public class BWEARTestPackagerMojo extends AbstractMojo {
        return fileList[0];
 	}
     
-//    /**
-//     * Finds the JAR file for the Module.
-//     * 
-//     * @param target the Module Output directory which is the target directory.
-//     * 
-//     * @return the Module JAR.
-//     * 
-//     * @throws Exception
-//     */
-//	private File getModuleJar(File target) throws Exception {
-//      File[] files = BWFileUtils.getFilesForType(target, ".jar");
-//      files = BWFileUtils.sortFilesByDateDesc(files);
-//      if(files.length == 0) {
-//       	throw new Exception("Module is not built yet. Please check your Application PO for the Module entry.");
-//      }
-//      return files[0];
-//	}
-
 	/**
 	 * Gets the Tibco XML file with the updated Module versions.
 	 * 
@@ -550,14 +531,5 @@ public class BWEARTestPackagerMojo extends AbstractMojo {
 			file.delete();
 		}
 		getLog().debug("cleaned up the temporary files.");
-    }
-    /**
-     *  Updated the Application manifest just like the module one
-     */
-    private void updateManifestVersion() {
-    	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-    	String qualifierVersion = VersionParser.getcalculatedOSGiVersion(version, Constants.TIMESTAMP);
-    	getLog().info("The OSGi verion is " + qualifierVersion + " for Maven version of " + version);
-    	manifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, qualifierVersion);
     }
 }

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setupenterprise/BWModuleTestPackageMojo.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/test/setupenterprise/BWModuleTestPackageMojo.java
@@ -98,8 +98,7 @@ public class BWModuleTestPackageMojo extends AbstractMojo {
 
             getLog().info("Updated the Manifest version ");
             
-            ManifestWriter.updateManifestVersion(project, manifest, qualifierReplacement);
-            updateManifestVersion();
+            ManifestWriter.udpateManifestAttributes(project, manifest, qualifierReplacement);
             
             getLog().info("Removing the externals entries if any. ");
             removeExternals();
@@ -299,13 +298,6 @@ public class BWModuleTestPackageMojo extends AbstractMojo {
     
     protected boolean isSharedModule(){
     	return manifest.getMainAttributes().getValue(Constants.TIBCO_SHARED_MODULE) == null ? false : true;
-    }
-
-    private void updateManifestVersion() {
-    	String version = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-    	String qualifierVersion = VersionParser.getcalculatedOSGiVersion(version, qualifierReplacement);
-    	getLog().info("The OSGi verion is " + qualifierVersion + " for Maven version of " + version);
-    	manifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, qualifierVersion);
     }
 
     private void removeExternals() {

--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/Constants.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/Constants.java
@@ -7,9 +7,11 @@ import java.util.Set;
 public interface Constants {
 	public static final String ADMINEXEC = "bwadmin";
 	public static final String BUNDLE_VERSION = "Bundle-Version";
+	public static final String ARCHIVE_FILE_VERSION = "Archive-File-Version";
 	public static final String BUNDLE_CLASSPATH = "Bundle-ClassPath";
 	public static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
 	public static final String BUNDLE_PROVIDE_CAPABILITY = "Provide-Capability";
+	public static final String BUNDLE_REQUIRE_CAPABILITY = "Require-Capability";
 	public static final String TIBCO_BW_EDITION = "TIBCO-BW-Edition";
 	public static final String BWCF = "bwcf";
 	public static final String PACKAGING_MODEL_NAMESPACE_URI = "http://schemas.tibco.com/tra/model/core/PackagingModel";


### PR DESCRIPTION

****What's this Pull request about?
Create module, application, shared module. Generate parent pom.  in module project add shared module as dependency.
Execute maven install or package and create ear.  
Now change the version of the project in all POMs from 1.0.0-SNAPSHOT to 2.0.0-SNAPSHOT.
Now trigger maven install or package.  The generated jar for the module will have dependency version of shared module as 1.0.0 even though 
it is changed now to 2.0.0.
Due to this when the ear is deployed on to docker, the application failed to start.


****Which Issue(s) this Pull Request will fix?
The dependency version is updated to match the version of the shared module.  The manifest is generated with modifications required.

****Does this pull request maintain backward compatibility?
All the artifacts created, manifests were generated and build is successful.  

****How this pull request has been tested?
1) Create a simple project with a shared module or import the project.
2) Mavenize first the Shared Module and then the application.
3) Now change the snapshot version from "1.0.0-SNAPSHOT" to "2.0.0-SNAPSHOT" in all the pom files present in the project.
4) Create the ear using Maven install. 
5) Deploy the EAR with BWCE 210 base image.
6) There will be no issues.