### PR TITLE
AMBW-52261 NullPointerException while running EAR with for External shared module.

### DIFF
--- a/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/BWModulesParser.java
+++ b/Source/bw6-maven-plugin/src/main/java/com/tibco/bw/maven/plugin/utils/BWModulesParser.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.jar.Manifest;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -19,9 +18,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-
-import com.tibco.bw.maven.plugin.osgi.helpers.ManifestParser;
-import com.tibco.bw.maven.plugin.utils.BWProjectUtils.MODULE;
 
 public class BWModulesParser {
 	private MavenSession session;
@@ -96,8 +92,8 @@ public class BWModulesParser {
 		
 		for(MavenProject project : projects) {
 			if(project.getArtifactId().contains(".module") ||  // from create a new business application path
-			   project.getArtifactId().contains("Module")	   // from create a new Business works application module path
-					){
+			   project.getArtifactId().contains("Module")  ||   // from create a new Business works application module path
+			   project.getArtifact().getType().equals("bwmodule")){
 				moduleProject = project;
 			}
 			if(project.getArtifactId().equals(module)) { 


### PR DESCRIPTION
****What's this Pull request about?
Create a shared module and install it.
Move to new workspace or clear all projects from workspace.
On creating BW application and module using 'Businessworks applicaiton module' option in the context menu or toolbar option.
On adding shared module reference to module created in POM, creating EAR fails.
This is due to artefact id not having module keyword, whcih is there in module created using 'create application' option.

****Which Issue(s) this Pull Request will fix?
Null pointer exception generated during EAR creation, where module is referring exported shared module.
Due to inconsitency in POM artefact id of module.

****Does this pull request maintain backward compatibility?
Yes, the fix has no changes in functionality.  The project creation and EAR generatrion will work in the same way.

****How this pull request has been tested?
Followed the test steps give in the ticket.