### PR TITLE
AMBW 54791

### DIFF
--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/mac_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/mac_environment.properties
@@ -29,6 +29,7 @@
 -Dosgi.noShutdown=true
 -Dorg.osgi.service.http.port=%%ENGINE_DEBUG_PORT%%
 -Dengine.test.mode=true
+-Dbw.mavenTesting.enabled=true
 -Djava.locale.providers=COMPAT,CLDR,SPI
 -Dbw.engine.enable.audit.events=true
 -Dtest.target.path=/target/site

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
@@ -26,6 +26,7 @@
 -Dosgi.noShutdown=true
 -Dorg.osgi.service.http.port=%%ENGINE_DEBUG_PORT%%
 -Dengine.test.mode=true
+-Dbw.mavenTesting.enabled=true
 -Djava.locale.providers=COMPAT,CLDR,SPI
 -Dbw.engine.enable.audit.events=true
 -Dtest.target.path=/target/site

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
@@ -29,6 +29,7 @@
 -Dosgi.noShutdown=true
 -Dorg.osgi.service.http.port=%%ENGINE_DEBUG_PORT%%
 -Dengine.test.mode=true
+-Dbw.mavenTesting.enabled=true
 -Djava.locale.providers=COMPAT,CLDR,SPI
 -Dbw.engine.enable.audit.events=true
 -Dtest.target.path=/target/site


### PR DESCRIPTION
The added property is for the "/bwut" servlet to be deployed at BW runtime in the separate JVM launched by Maven test.

****What's this Pull request about?
The goals is to have the "/bwut" servlet to be deployed at BW runtime when running BW maven test.

****Which Issue(s) this Pull Request will fix?
This pull request is for resolving JIRA https://tibco.atlassian.net/browse/AMBW-54791

****Does this pull request maintain backward compatibility?
Yes. There is no change to existing code. Only a new property is added.

****How this pull request has been tested?
A jar file with the updated properties files are manually created and deployed to a .m2 folder , e.g. C:\Users\yayang.m2\repository\com\tibco\plugins\bw6-maven-plugin\2.11.0\bw6-maven-plugin-2.11.0.jar.
Then the BW maven test is run again. The issue does not occur with the updated jar file.
Please see comments in https://tibco.atlassian.net/browse/AMBW-54791 for more details.

****Screenshots (if appropriate)
<img width="1728" height="1036" alt="image" src="https://github.com/user-attachments/assets/88221c8a-513a-4c2e-9875-3926c80178f3" />

<img width="1728" height="1036" alt="image" src="https://github.com/user-attachments/assets/b35198f1-fd72-4421-bda3-ff24afdf2061" />

Please see comments in https://tibco.atlassian.net/browse/AMBW-54791 for more details.

****Any background context or comments you want to provide?
Before Nova changes, multiple servlets are started by default at BW runtime, which contributes to the initial startup time of BW runtime. To improve that, the starting of the servlets are changed to be based on system properties. The idea is that a servlet is started when the associated feature is enabled and the enablement of a feature can be based on system property.

This is the document to keep track of the servlets and changes made:
https://docs.google.com/spreadsheets/d/1vCNM7W2lBWzZR_SvBpWeHPBxx9IPXMSj41RqsIhMhSY/edit?gid=1015019536#gid=1015019536

With Nova changes, for the "/bwut" servlet:
(1) The servlet is not started by default, when system property "bw.mavenTesting.enabled" is not set or is false.
(2) The servlet is started when system property "bw.mavenTesting.enabled" is true.
(3) In BW studio launch configuration -> Advanced tab, a [Enable Maven Testing] checkbox is added. It is not selected by default. When it is selected, in the BW runtime launched in BW studio, maven testing feature is enabled and the system property "bw.mavenTesting.enabled" is set to true. Then the "/bwut" servlet is started.
<img width="1728" height="1084" alt="image" src="https://github.com/user-attachments/assets/530a2871-e635-4b22-86cf-aae4260737ad" />
