### PR TITLE
Add -Dbw.monitor.asyncRegisterServlet.enabled=false to the three properties files.

### DIFF
--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/mac_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/mac_environment.properties
@@ -30,6 +30,7 @@
 -Dorg.osgi.service.http.port=%%ENGINE_DEBUG_PORT%%
 -Dengine.test.mode=true
 -Dbw.mavenTesting.enabled=true
+-Dbw.monitor.asyncRegisterServlet.enabled=false
 -Djava.locale.providers=COMPAT,CLDR,SPI
 -Dbw.engine.enable.audit.events=true
 -Dtest.target.path=/target/site

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/unix_environment.properties
@@ -27,6 +27,7 @@
 -Dorg.osgi.service.http.port=%%ENGINE_DEBUG_PORT%%
 -Dengine.test.mode=true
 -Dbw.mavenTesting.enabled=true
+-Dbw.monitor.asyncRegisterServlet.enabled=false
 -Djava.locale.providers=COMPAT,CLDR,SPI
 -Dbw.engine.enable.audit.events=true
 -Dtest.target.path=/target/site

--- a/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
+++ b/Source/bw6-maven-plugin/src/main/resources/com/tibco/resources/win_environment.properties
@@ -30,6 +30,7 @@
 -Dorg.osgi.service.http.port=%%ENGINE_DEBUG_PORT%%
 -Dengine.test.mode=true
 -Dbw.mavenTesting.enabled=true
+-Dbw.monitor.asyncRegisterServlet.enabled=false
 -Djava.locale.providers=COMPAT,CLDR,SPI
 -Dbw.engine.enable.audit.events=true
 -Dtest.target.path=/target/site


### PR DESCRIPTION
Add **-Dbw.monitor.asyncRegisterServlet.enabled=false** to the three properties files to address the intermittent HTTP 404 errors during mvn test execution.

****What's this Pull request about?
To address the intermittent HTTP 404 errors during mvn test execution, in the BW Maven plugin, add -Dbw.monitor.asyncRegisterServlet.enabled=false to the three properties files.

****Which Issue(s) this Pull Request will fix?
This pull request is for resolving JIRA https://tibco.atlassian.net/browse/AMBW-55385

****Does this pull request maintain backward compatibility?
Yes. There is no change to existing code. Only a new property is added.

****How this pull request has been tested?
A JAR file containing the updated properties files was manually created and deployed to the .m2 repository folder (mvn clean package), 
for example: C:\Users\spawale\.m2\repository\com\tibco\plugins\bw6-maven-plugin\2.12.0\bw6-maven-plugin-2.12.0.jar.
After that, I restarted Studio and ran the Maven test again. With the updated changes the issues no longer occur.



